### PR TITLE
feat(video): add video recording with OpenCV + mock recorder

### DIFF
--- a/examples/webcam_recording.py
+++ b/examples/webcam_recording.py
@@ -1,0 +1,140 @@
+"""RoomKit -- Webcam recording: capture camera to MP4 file.
+
+Records webcam frames to an MP4 file using OpenCVVideoRecorder.
+Pure recording — no AI, no vision, just camera → MP4.
+
+Prerequisites:
+    pip install roomkit[local-video]
+
+Run with:
+    uv run python examples/webcam_recording.py
+    uv run python examples/webcam_recording.py --duration 30
+    uv run python examples/webcam_recording.py --output ./my_recordings
+    uv run python examples/webcam_recording.py --fps 30 --device 0
+
+Press Ctrl+C to stop early.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import logging
+import signal
+
+from roomkit import (
+    HookExecution,
+    HookTrigger,
+    RoomKit,
+    VideoChannel,
+    VideoFrame,
+)
+from roomkit.models.session_event import SessionStartedEvent
+from roomkit.video.backends.local import LocalVideoBackend
+from roomkit.video.recorder import MockVideoRecorder, VideoRecordingConfig
+
+logging.basicConfig(level=logging.WARNING)
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Webcam Recording Demo")
+    parser.add_argument("--device", type=int, default=0, help="Camera device index")
+    parser.add_argument("--fps", type=int, default=15, help="Capture FPS")
+    parser.add_argument("--duration", type=int, default=0, help="Record N seconds (0=Ctrl+C)")
+    parser.add_argument("--output", default="./recordings", help="Output directory")
+    args = parser.parse_args()
+
+    kit = RoomKit()
+
+    # --- Video backend: local webcam -----------------------------------------
+    backend = LocalVideoBackend(device=args.device, fps=args.fps, width=640, height=480)
+
+    # --- Recorder: OpenCV if available, mock fallback ------------------------
+    try:
+        from roomkit.video.recorder.opencv import OpenCVVideoRecorder
+
+        recorder = OpenCVVideoRecorder()
+        recorder_name = "OpenCV → MP4"
+    except ImportError:
+        recorder = MockVideoRecorder()
+        recorder_name = "Mock (no opencv)"
+
+    recording_config = VideoRecordingConfig(
+        storage=args.output,
+        format="mp4",
+        fps=float(args.fps),
+    )
+
+    # --- Video channel with recorder -----------------------------------------
+    video = VideoChannel(
+        "video-rec",
+        backend=backend,
+        recorder=recorder,
+        recording_config=recording_config,
+    )
+    kit.register_channel(video)
+
+    # --- Room setup ----------------------------------------------------------
+    await kit.create_room(room_id="recording-demo")
+    await kit.attach_channel("recording-demo", "video-rec")
+
+    # --- Hooks: log events ---------------------------------------------------
+    frame_count = 0
+
+    @kit.hook(HookTrigger.ON_VIDEO_SESSION_STARTED, execution=HookExecution.ASYNC)
+    async def on_started(event: SessionStartedEvent, ctx: object) -> None:
+        print(f"  Session started: {event.session.id[:8]}...")  # type: ignore[union-attr]
+
+    def on_frame(session: object, frame: VideoFrame) -> None:
+        nonlocal frame_count
+        frame_count += 1
+        if frame_count % args.fps == 0:
+            secs = frame_count // args.fps
+            print(f"\r  Recording... {secs}s ({frame_count} frames)", end="", flush=True)
+
+    backend.on_video_received(on_frame)
+
+    # --- Connect and start ---------------------------------------------------
+    session = await kit.connect_video("recording-demo", "local-user", "video-rec")
+
+    print("Webcam Recording Demo")
+    print("=" * 60)
+    print(f"Recorder: {recorder_name}")
+    print(f"Camera: device {args.device} at 640x480 @ {args.fps}fps")
+    print(f"Output: {args.output}/")
+    if args.duration:
+        print(f"Duration: {args.duration}s")
+    else:
+        print("Duration: until Ctrl+C")
+    print()
+
+    await backend.start_capture(session)
+
+    # --- Wait for duration or Ctrl+C ----------------------------------------
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig_name in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig_name, stop.set)
+
+    if args.duration:
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(stop.wait(), timeout=args.duration)
+    else:
+        await stop.wait()
+
+    # --- Cleanup -------------------------------------------------------------
+    print("\n\n  Stopping...")
+    await backend.stop_capture(session)
+    await kit.disconnect_video(session)
+    await kit.close()
+
+    # Show recording info
+    handle = list(recorder.recordings.values())[0] if hasattr(recorder, "recordings") else None
+    if handle:
+        print(f"  Recorded {frame_count} frames")
+    print("  Done.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/roomkit/channels/video.py
+++ b/src/roomkit/channels/video.py
@@ -27,6 +27,11 @@ if TYPE_CHECKING:
     from roomkit.models.event import RoomEvent
     from roomkit.video.backends.base import VideoBackend
     from roomkit.video.base import VideoSession
+    from roomkit.video.recorder.base import (
+        VideoRecorder,
+        VideoRecordingConfig,
+        VideoRecordingHandle,
+    )
     from roomkit.video.video_frame import VideoFrame
     from roomkit.video.vision.base import VisionProvider, VisionResult
 
@@ -52,11 +57,15 @@ class VideoChannel(VideoHooksMixin, Channel):
         backend: VideoBackend,
         vision: VisionProvider | None = None,
         vision_interval_ms: int = 2000,
+        recorder: VideoRecorder | None = None,
+        recording_config: VideoRecordingConfig | None = None,
     ) -> None:
         super().__init__(channel_id)
         self._backend = backend
         self._vision = vision
         self._vision_interval_ms = vision_interval_ms
+        self._recorder = recorder
+        self._recording_config = recording_config
         self._framework: RoomKit | None = None
 
         # Map session_id -> (room_id, binding) for routing
@@ -71,6 +80,8 @@ class VideoChannel(VideoHooksMixin, Channel):
         self._session_ready_pending: set[str] = set()
         # Cached event loop for cross-thread scheduling
         self._event_loop: asyncio.AbstractEventLoop | None = None
+        # Active recording handles per session
+        self._recording_handles: dict[str, VideoRecordingHandle] = {}
 
         # Wire backend callbacks
         backend.on_video_received(self._on_video_received)
@@ -170,6 +181,14 @@ class VideoChannel(VideoHooksMixin, Channel):
                 self._emit_session_event("video_session_started", session, room_id),
                 name=f"video_session_started:{session.id}",
             )
+        # Start recording if configured
+        if self._recorder and self._recording_config:
+            from roomkit.video.recorder.base import VideoRecordingConfig
+
+            config = self._recording_config or VideoRecordingConfig()
+            handle = self._recorder.start(session, config)
+            self._recording_handles[session.id] = handle
+            logger.info("Recording started: %s for session %s", handle.id, session.id[:8])
         # Fire hook if backend was already ready
         if was_ready_pending and self._framework:
             self._schedule(
@@ -180,6 +199,16 @@ class VideoChannel(VideoHooksMixin, Channel):
     def unbind_session(self, session: VideoSession) -> None:
         """Remove session binding and clean up state."""
         self._session_ready_pending.discard(session.id)
+        # Stop recording
+        handle = self._recording_handles.pop(session.id, None)
+        if handle and self._recorder:
+            result = self._recorder.stop(handle)
+            logger.info(
+                "Recording stopped: %s (%d frames, %.1fs)",
+                result.id,
+                result.frame_count,
+                result.duration_seconds,
+            )
         binding_info = self._session_bindings.pop(session.id, None)
         self._last_vision_results.pop(session.id, None)
         self._last_vision_ts.pop(session.id, None)
@@ -221,6 +250,10 @@ class VideoChannel(VideoHooksMixin, Channel):
         binding_info = self._session_bindings.get(session.id)
         if binding_info is None:
             return
+        # Recorder tap runs on every frame
+        rec_handle = self._recording_handles.get(session.id)
+        if rec_handle and self._recorder:
+            self._recorder.tap_frame(rec_handle, frame)
         if self._vision is None:
             return
         # Throttle before creating a task — avoids O(fps) task allocation
@@ -291,6 +324,12 @@ class VideoChannel(VideoHooksMixin, Channel):
         if self._scheduled_tasks:
             await asyncio.gather(*self._scheduled_tasks, return_exceptions=True)
         self._scheduled_tasks.clear()
+        # Stop active recordings
+        if self._recorder:
+            for handle in self._recording_handles.values():
+                self._recorder.stop(handle)
+            self._recorder.close()
+        self._recording_handles.clear()
         # Close vision provider
         if self._vision:
             await self._vision.close()

--- a/src/roomkit/video/__init__.py
+++ b/src/roomkit/video/__init__.py
@@ -14,6 +14,13 @@ from roomkit.video.base import (
     VideoSessionReadyCallback,
     VideoSessionState,
 )
+from roomkit.video.recorder import (
+    MockVideoRecorder,
+    VideoRecorder,
+    VideoRecordingConfig,
+    VideoRecordingHandle,
+    VideoRecordingResult,
+)
 from roomkit.video.video_frame import VideoFrame
 from roomkit.video.vision.base import FaceDetection, VisionProvider, VisionResult
 from roomkit.video.vision.gemini import GeminiVisionConfig, GeminiVisionProvider
@@ -40,6 +47,12 @@ __all__ = [
     "OpenAIVisionProvider",
     "VisionProvider",
     "VisionResult",
+    # Recording
+    "MockVideoRecorder",
+    "VideoRecorder",
+    "VideoRecordingConfig",
+    "VideoRecordingHandle",
+    "VideoRecordingResult",
     # Mocks
     "MockVideoBackend",
     "MockVideoCall",

--- a/src/roomkit/video/recorder/__init__.py
+++ b/src/roomkit/video/recorder/__init__.py
@@ -1,0 +1,19 @@
+"""Video recording providers."""
+
+from __future__ import annotations
+
+from roomkit.video.recorder.base import (
+    VideoRecorder,
+    VideoRecordingConfig,
+    VideoRecordingHandle,
+    VideoRecordingResult,
+)
+from roomkit.video.recorder.mock import MockVideoRecorder
+
+__all__ = [
+    "MockVideoRecorder",
+    "VideoRecorder",
+    "VideoRecordingConfig",
+    "VideoRecordingHandle",
+    "VideoRecordingResult",
+]

--- a/src/roomkit/video/recorder/base.py
+++ b/src/roomkit/video/recorder/base.py
@@ -1,0 +1,86 @@
+"""Video recorder ABC and related data types."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from roomkit.video.base import VideoSession
+    from roomkit.video.video_frame import VideoFrame
+
+
+@dataclass
+class VideoRecordingConfig:
+    """Configuration for video recording.
+
+    Attributes:
+        storage: Directory path for recording files.
+        format: Output container format (``mp4``, ``avi``, ``mkv``).
+        codec: Video codec (``mp4v``, ``XVID``, ``avc1``).
+        fps: Output frame rate. If 0, uses the frame timestamps.
+        metadata: Provider-specific extra configuration.
+    """
+
+    storage: str = ""
+    format: str = "mp4"
+    codec: str = "mp4v"
+    fps: float = 15.0
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class VideoRecordingHandle:
+    """Handle to an active video recording."""
+
+    id: str
+    session_id: str
+    state: str = "recording"
+    started_at: datetime | None = None
+    path: str = ""
+
+
+@dataclass
+class VideoRecordingResult:
+    """Result returned when a video recording is stopped."""
+
+    id: str
+    url: str = ""
+    duration_seconds: float = 0.0
+    frame_count: int = 0
+    format: str = "mp4"
+    size_bytes: int = 0
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+class VideoRecorder(ABC):
+    """Abstract base class for video recording providers."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Provider name."""
+        ...
+
+    @abstractmethod
+    def start(self, session: VideoSession, config: VideoRecordingConfig) -> VideoRecordingHandle:
+        """Start recording a video session."""
+        ...
+
+    @abstractmethod
+    def stop(self, handle: VideoRecordingHandle) -> VideoRecordingResult:
+        """Stop an active recording and finalize the file."""
+        ...
+
+    @abstractmethod
+    def tap_frame(self, handle: VideoRecordingHandle, frame: VideoFrame) -> None:
+        """Feed a video frame to the recorder."""
+        ...
+
+    def reset(self) -> None:  # noqa: B027
+        """Reset internal state."""
+
+    def close(self) -> None:  # noqa: B027
+        """Release resources."""

--- a/src/roomkit/video/recorder/mock.py
+++ b/src/roomkit/video/recorder/mock.py
@@ -1,0 +1,67 @@
+"""Mock video recorder for testing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from roomkit.video.recorder.base import (
+    VideoRecorder,
+    VideoRecordingConfig,
+    VideoRecordingHandle,
+    VideoRecordingResult,
+)
+
+if TYPE_CHECKING:
+    from roomkit.video.base import VideoSession
+    from roomkit.video.video_frame import VideoFrame
+
+
+@dataclass
+class MockRecordingEntry:
+    """Tracked recording in MockVideoRecorder."""
+
+    handle: VideoRecordingHandle
+    frames: list[VideoFrame] = field(default_factory=list)
+
+
+class MockVideoRecorder(VideoRecorder):
+    """Mock video recorder that tracks frames in memory."""
+
+    def __init__(self) -> None:
+        self.recordings: dict[str, MockRecordingEntry] = {}
+        self._counter = 0
+
+    @property
+    def name(self) -> str:
+        return "MockVideoRecorder"
+
+    def start(self, session: VideoSession, config: VideoRecordingConfig) -> VideoRecordingHandle:
+        self._counter += 1
+        rec_id = f"rec_{self._counter}"
+        handle = VideoRecordingHandle(
+            id=rec_id,
+            session_id=session.id,
+            started_at=datetime.now(UTC),
+            path=f"{config.storage or 'mock'}/{rec_id}.{config.format}",
+        )
+        self.recordings[rec_id] = MockRecordingEntry(handle=handle)
+        return handle
+
+    def stop(self, handle: VideoRecordingHandle) -> VideoRecordingResult:
+        handle.state = "stopped"
+        entry = self.recordings.get(handle.id)
+        frame_count = len(entry.frames) if entry else 0
+        return VideoRecordingResult(
+            id=handle.id,
+            url=handle.path,
+            frame_count=frame_count,
+            duration_seconds=frame_count / 15.0,
+            size_bytes=frame_count * 921_600,
+        )
+
+    def tap_frame(self, handle: VideoRecordingHandle, frame: VideoFrame) -> None:
+        entry = self.recordings.get(handle.id)
+        if entry is not None:
+            entry.frames.append(frame)

--- a/src/roomkit/video/recorder/opencv.py
+++ b/src/roomkit/video/recorder/opencv.py
@@ -1,0 +1,171 @@
+"""OpenCV video recorder — writes frames to MP4/AVI files.
+
+Requires ``opencv-python-headless``::
+
+    pip install roomkit[local-video]
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from roomkit.video.recorder.base import (
+    VideoRecorder,
+    VideoRecordingConfig,
+    VideoRecordingHandle,
+    VideoRecordingResult,
+)
+
+if TYPE_CHECKING:
+    from roomkit.video.base import VideoSession
+    from roomkit.video.video_frame import VideoFrame
+
+logger = logging.getLogger("roomkit.video.recorder.opencv")
+
+
+def _import_cv2() -> Any:
+    """Import OpenCV, raising a clear error if missing."""
+    try:
+        import cv2
+
+        return cv2
+    except ImportError as exc:
+        raise ImportError(
+            "opencv-python-headless is required for OpenCVVideoRecorder. "
+            "Install with: pip install roomkit[local-video]"
+        ) from exc
+
+
+def _safe_filename(session_id: str) -> str:
+    """Sanitize session ID for use in filenames."""
+    return re.sub(r"[^\w\-]", "_", session_id)
+
+
+class _ActiveRecording:
+    """Internal state for an active recording."""
+
+    __slots__ = ("writer", "frame_count", "start_time", "path", "cv2")
+
+    def __init__(self, writer: Any, path: str, cv2_mod: Any) -> None:
+        self.writer = writer
+        self.path = path
+        self.cv2 = cv2_mod
+        self.frame_count = 0
+        self.start_time = time.monotonic()
+
+
+class OpenCVVideoRecorder(VideoRecorder):
+    """Video recorder using OpenCV's VideoWriter.
+
+    Writes raw RGB frames to MP4 (or AVI) files. Frames are
+    converted from RGB to BGR (OpenCV native) before writing.
+    """
+
+    def __init__(self) -> None:
+        self._cv2 = _import_cv2()
+        self._active: dict[str, _ActiveRecording] = {}
+
+    @property
+    def name(self) -> str:
+        return "OpenCVVideoRecorder"
+
+    def start(self, session: VideoSession, config: VideoRecordingConfig) -> VideoRecordingHandle:
+        rec_id = uuid4().hex[:12]
+        safe_id = _safe_filename(session.id[:16])
+        ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
+        filename = f"{safe_id}_{ts}.{config.format}"
+
+        storage = config.storage or os.path.join(os.getcwd(), "recordings")
+        if ".." in storage:
+            raise ValueError(f"Storage path must not contain '..': {storage}")
+        os.makedirs(storage, exist_ok=True)
+        path = os.path.join(storage, filename)
+
+        # Writer is created lazily on first frame (need dimensions)
+        handle = VideoRecordingHandle(
+            id=rec_id,
+            session_id=session.id,
+            started_at=datetime.now(UTC),
+            path=path,
+        )
+        self._active[rec_id] = _ActiveRecording(writer=None, path=path, cv2_mod=self._cv2)
+        logger.info("Recording started: %s → %s", rec_id, path)
+        return handle
+
+    def stop(self, handle: VideoRecordingHandle) -> VideoRecordingResult:
+        handle.state = "stopped"
+        active = self._active.pop(handle.id, None)
+        if active is None:
+            return VideoRecordingResult(id=handle.id)
+
+        if active.writer is not None:
+            active.writer.release()
+
+        elapsed = time.monotonic() - active.start_time
+        size = 0
+        if os.path.exists(active.path):
+            size = os.path.getsize(active.path)
+
+        logger.info(
+            "Recording stopped: %s (%d frames, %.1fs, %d bytes)",
+            handle.id,
+            active.frame_count,
+            elapsed,
+            size,
+        )
+        return VideoRecordingResult(
+            id=handle.id,
+            url=active.path,
+            frame_count=active.frame_count,
+            duration_seconds=round(elapsed, 2),
+            format=os.path.splitext(active.path)[1].lstrip("."),
+            size_bytes=size,
+        )
+
+    def tap_frame(self, handle: VideoRecordingHandle, frame: VideoFrame) -> None:
+        active = self._active.get(handle.id)
+        if active is None:
+            return
+
+        cv2 = active.cv2
+
+        # Lazy-create writer on first frame (now we know dimensions)
+        if active.writer is None:
+            fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+            active.writer = cv2.VideoWriter(active.path, fourcc, 15.0, (frame.width, frame.height))
+            if not active.writer.isOpened():
+                logger.error("Failed to open VideoWriter for %s", active.path)
+                return
+
+        # Convert raw RGB to BGR for OpenCV
+        if frame.codec == "raw_rgb24":
+            import numpy as np
+
+            pixels = np.frombuffer(frame.data, dtype=np.uint8).reshape(
+                frame.height, frame.width, 3
+            )
+            bgr = cv2.cvtColor(pixels, cv2.COLOR_RGB2BGR)
+            active.writer.write(bgr)
+            active.frame_count += 1
+        elif frame.codec == "raw_bgr24":
+            import numpy as np
+
+            bgr = np.frombuffer(frame.data, dtype=np.uint8).reshape(frame.height, frame.width, 3)
+            active.writer.write(bgr)
+            active.frame_count += 1
+        else:
+            # Encoded frames can't be written directly by VideoWriter
+            logger.debug("Skipping encoded frame (codec=%s)", frame.codec)
+
+    def close(self) -> None:
+        for rec_id, active in list(self._active.items()):
+            if active.writer is not None:
+                active.writer.release()
+            logger.info("Recording closed: %s", rec_id)
+        self._active.clear()

--- a/tests/test_video_recording.py
+++ b/tests/test_video_recording.py
@@ -1,0 +1,175 @@
+"""Tests for video recording — VideoRecorder ABC, Mock, and channel integration."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from roomkit import (
+    MockVideoBackend,
+    RoomKit,
+    VideoChannel,
+    VideoFrame,
+)
+from roomkit.video.recorder import (
+    MockVideoRecorder,
+    VideoRecordingConfig,
+)
+
+
+@pytest.fixture
+def kit() -> RoomKit:
+    return RoomKit()
+
+
+class TestMockVideoRecorder:
+    def test_start_stop(self) -> None:
+        from roomkit.video.base import VideoSession
+
+        recorder = MockVideoRecorder()
+        session = VideoSession(id="s1", room_id="r1", participant_id="u1", channel_id="v1")
+        config = VideoRecordingConfig(storage="/tmp/test")
+
+        handle = recorder.start(session, config)
+        assert handle.state == "recording"
+        assert handle.session_id == "s1"
+        assert "rec_1" in handle.id
+
+        result = recorder.stop(handle)
+        assert handle.state == "stopped"
+        assert result.frame_count == 0
+        assert result.id == handle.id
+
+    def test_tap_frame(self) -> None:
+        from roomkit.video.base import VideoSession
+
+        recorder = MockVideoRecorder()
+        session = VideoSession(id="s1", room_id="r1", participant_id="u1", channel_id="v1")
+        handle = recorder.start(session, VideoRecordingConfig())
+
+        frame = VideoFrame(data=b"\x00" * 100, codec="h264")
+        recorder.tap_frame(handle, frame)
+        recorder.tap_frame(handle, frame)
+
+        result = recorder.stop(handle)
+        assert result.frame_count == 2
+
+    def test_multiple_recordings(self) -> None:
+        from roomkit.video.base import VideoSession
+
+        recorder = MockVideoRecorder()
+        s1 = VideoSession(id="s1", room_id="r1", participant_id="u1", channel_id="v1")
+        s2 = VideoSession(id="s2", room_id="r1", participant_id="u2", channel_id="v1")
+
+        h1 = recorder.start(s1, VideoRecordingConfig())
+        h2 = recorder.start(s2, VideoRecordingConfig())
+
+        assert h1.id != h2.id
+        assert len(recorder.recordings) == 2
+
+
+class TestVideoChannelRecording:
+    async def test_recording_starts_on_bind(self, kit: RoomKit) -> None:
+        backend = MockVideoBackend()
+        recorder = MockVideoRecorder()
+        ch = VideoChannel(
+            "video-1",
+            backend=backend,
+            recorder=recorder,
+            recording_config=VideoRecordingConfig(),
+        )
+        kit.register_channel(ch)
+        await kit.create_room(room_id="r1")
+        await kit.attach_channel("r1", "video-1")
+
+        session = await kit.connect_video("r1", "user-1", "video-1")
+
+        # Recording should have started
+        assert session.id in ch._recording_handles
+        assert len(recorder.recordings) == 1
+
+    async def test_recording_stops_on_unbind(self, kit: RoomKit) -> None:
+        backend = MockVideoBackend()
+        recorder = MockVideoRecorder()
+        ch = VideoChannel(
+            "video-1",
+            backend=backend,
+            recorder=recorder,
+            recording_config=VideoRecordingConfig(),
+        )
+        kit.register_channel(ch)
+        await kit.create_room(room_id="r1")
+        await kit.attach_channel("r1", "video-1")
+
+        session = await kit.connect_video("r1", "user-1", "video-1")
+        await kit.disconnect_video(session)
+
+        assert session.id not in ch._recording_handles
+        # Recording was stopped
+        rec = list(recorder.recordings.values())[0]
+        assert rec.handle.state == "stopped"
+
+    async def test_frames_tapped_to_recorder(self, kit: RoomKit) -> None:
+        backend = MockVideoBackend()
+        recorder = MockVideoRecorder()
+        ch = VideoChannel(
+            "video-1",
+            backend=backend,
+            recorder=recorder,
+            recording_config=VideoRecordingConfig(),
+        )
+        kit.register_channel(ch)
+        await kit.create_room(room_id="r1")
+        await kit.attach_channel("r1", "video-1")
+
+        session = await kit.connect_video("r1", "user-1", "video-1")
+
+        # Send frames
+        for i in range(5):
+            frame = VideoFrame(data=b"\x00" * 100, codec="h264", timestamp_ms=float(i * 100))
+            await backend.simulate_video_received(session, frame)
+        await asyncio.sleep(0.05)
+
+        rec = list(recorder.recordings.values())[0]
+        assert len(rec.frames) == 5
+
+    async def test_no_recorder_no_error(self, kit: RoomKit) -> None:
+        """Channel works fine without a recorder."""
+        backend = MockVideoBackend()
+        ch = VideoChannel("video-1", backend=backend)
+        kit.register_channel(ch)
+        await kit.create_room(room_id="r1")
+        await kit.attach_channel("r1", "video-1")
+
+        session = await kit.connect_video("r1", "user-1", "video-1")
+        frame = VideoFrame(data=b"\x00" * 100, codec="h264")
+        await backend.simulate_video_received(session, frame)
+        await kit.disconnect_video(session)
+
+    async def test_close_stops_recordings(self, kit: RoomKit) -> None:
+        backend = MockVideoBackend()
+        recorder = MockVideoRecorder()
+        ch = VideoChannel(
+            "video-1",
+            backend=backend,
+            recorder=recorder,
+            recording_config=VideoRecordingConfig(),
+        )
+        kit.register_channel(ch)
+        await kit.create_room(room_id="r1")
+        await kit.attach_channel("r1", "video-1")
+
+        await kit.connect_video("r1", "user-1", "video-1")
+        await ch.close()
+
+        assert ch._recording_handles == {}
+
+
+class TestOpenCVVideoRecorder:
+    def test_import(self) -> None:
+        pytest.importorskip("cv2", reason="opencv not installed")
+        from roomkit.video.recorder.opencv import OpenCVVideoRecorder
+
+        recorder = OpenCVVideoRecorder()
+        assert recorder.name == "OpenCVVideoRecorder"


### PR DESCRIPTION
## Summary

- VideoRecorder ABC with start/stop/tap_frame lifecycle (mirrors AudioRecorder)
- OpenCVVideoRecorder: writes raw RGB frames to MP4 via cv2.VideoWriter
- MockVideoRecorder: tracks frames in memory for testing
- VideoChannel integration: recorder taps every received frame, starts on bind, stops on unbind
- 9 new tests

## Test plan

- [x] MockVideoRecorder: start/stop, tap_frame, multiple recordings
- [x] Channel integration: recording starts on bind, stops on unbind, frames tapped
- [x] No-recorder path: channel works without recorder configured
- [x] Close cleanup: stops all active recordings
- [x] OpenCV import check

🤖 Generated with [Claude Code](https://claude.com/claude-code)