### PR TITLE
fix(ai): make read_stored_result callable in the turn that evicted

### DIFF
--- a/src/roomkit/channels/_ai_loop_rules.py
+++ b/src/roomkit/channels/_ai_loop_rules.py
@@ -19,6 +19,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from roomkit.channels._tool_eviction import ToolEviction
 from roomkit.providers.ai.base import (
     AIMessage,
     AITextPart,
@@ -98,6 +99,7 @@ class AIToolLoopRulesHost(Protocol):
     _tool_loop_timeout_seconds: float | None
     _tool_loop_warn_after: int
     _max_empty_retries: int
+    _eviction: ToolEviction
 
     def _apply_tool_filters(self, tools: list[Any]) -> list[Any]: ...
     async def _publish_tool_event(
@@ -127,6 +129,7 @@ class AIToolLoopRulesMixin:
     _tool_loop_timeout_seconds: float | None
     _tool_loop_warn_after: int
     _max_empty_retries: int
+    _eviction: ToolEviction
 
     # Cross-mixin methods — Any annotations avoid MRO shadowing.
     _apply_tool_filters: Any  # see AIToolLoopRulesHost
@@ -166,10 +169,27 @@ class AIToolLoopRulesMixin:
                 context.messages.append(AIMessage(role="user", content=_FORCE_STOP_NUDGE))
                 state.force_stop_nudged = True
             return context.model_copy(update={"tools": []})
+
+        tools: list[Any] | None = None
         if loop_ctx.all_context_tools:
-            return context.model_copy(
-                update={"tools": self._apply_tool_filters(loop_ctx.all_context_tools)}
-            )
+            tools = self._apply_tool_filters(loop_ctx.all_context_tools)
+
+        # A result evicted mid-loop replaces itself with a preview that tells
+        # the model to page the full output back with ``read_stored_result`` —
+        # but that tool was only ever injected at ``_build_context`` time, i.e.
+        # on the *next inbound event*, and every round here re-filters from the
+        # frozen ``all_context_tools`` snapshot. So the tool was unreachable in
+        # the very turn whose preview recommends it, and a one-shot automation
+        # run (webhook, schedule) has no next event at all: its evicted content
+        # was simply lost. Inject the definition per round instead — the
+        # dispatch table already accepts the call unconditionally.
+        if self._eviction.has_evicted:
+            current = tools if tools is not None else list(context.tools or [])
+            if all(t.name != "read_stored_result" for t in current):
+                tools = [*current, ToolEviction.tool_definition()]
+
+        if tools is not None:
+            return context.model_copy(update={"tools": tools})
         return context
 
     def _try_empty_retry(

--- a/tests/test_channels/test_ai_tool_loop.py
+++ b/tests/test_channels/test_ai_tool_loop.py
@@ -651,3 +651,78 @@ class TestExtractAccumulatedText:
         messages = [AIMessage(role="user", content="hello")]
         result = AIChannel._extract_accumulated_text(messages)
         assert result == ""
+
+
+class TestEvictionToolAvailableMidLoop:
+    """A mid-loop eviction must make ``read_stored_result`` callable
+    in the same turn.
+
+    The eviction preview tells the model to page the result back with
+    ``read_stored_result``, but the definition was only injected at
+    ``_build_context`` time — the next inbound event — while every round
+    re-filters from the frozen turn snapshot. A one-shot automation run
+    (webhook, schedule) has no next event at all, so its evicted content
+    was unreachable exactly when the preview recommended reading it, and
+    the model burned rounds hunting for a tool that did not exist.
+    """
+
+    async def test_read_stored_result_is_injected_the_round_after_eviction(self) -> None:
+        large = "\n".join(f"NEEDLE-{i} " + "x" * 80 for i in range(200))
+        provider = MockAIProvider(
+            ai_responses=[
+                _tool_response(tool_name="search"),
+                AIResponse(
+                    content="",
+                    tool_calls=[
+                        AIToolCall(
+                            id="tc2",
+                            name="read_stored_result",
+                            arguments={"result_id": "evicted_tc1"},
+                        )
+                    ],
+                ),
+                _final_response(),
+            ]
+        )
+        handler = AsyncMock(return_value=large)
+        ch = AIChannel(
+            "ai1",
+            provider=provider,
+            tool_handler=handler,
+            evict_threshold_tokens=100,
+        )
+
+        context = AIContext(messages=[AIMessage(role="user", content="go")])
+        await ch._run_tool_loop(context)
+
+        # The round *after* the eviction advertises the re-read tool…
+        assert len(provider.calls) == 3
+        round2_tools = [t.name for t in (provider.calls[1].tools or [])]
+        assert "read_stored_result" in round2_tools
+
+        # …and the call is channel-managed: the user handler ran only for
+        # the evicting tool, never for read_stored_result.
+        assert handler.await_count == 1
+
+        # The paged content actually came back into the conversation.
+        final_messages = str(provider.calls[2].messages)
+        assert "NEEDLE-0" in final_messages
+
+    async def test_no_injection_when_nothing_was_evicted(self) -> None:
+        provider = MockAIProvider(
+            ai_responses=[_tool_response(tool_name="search"), _final_response()]
+        )
+        handler = AsyncMock(return_value="small result")
+        ch = AIChannel(
+            "ai1",
+            provider=provider,
+            tool_handler=handler,
+            evict_threshold_tokens=5000,
+        )
+
+        context = AIContext(messages=[AIMessage(role="user", content="go")])
+        await ch._run_tool_loop(context)
+
+        assert len(provider.calls) == 2
+        round2_tools = [t.name for t in (provider.calls[1].tools or [])]
+        assert "read_stored_result" not in round2_tools


### PR DESCRIPTION
## The bug

When a tool result crosses the eviction threshold mid-loop, `maybe_evict` replaces it with a preview that says:

> Result too large (N tokens). Full output saved as 'evicted_…'. **Use read_stored_result** to read it with pagination.

But the `read_stored_result` definition is only injected at `_build_context` time (`_ai_context.py`: `if self._eviction.has_evicted: tools.append(...)`) — i.e. on the **next inbound event** — while every round of both tool loops re-filters from the frozen `loop_ctx.all_context_tools` snapshot (`_ai_loop_rules.py::_prepare_round_context`). So the tool does not exist in the very turn whose preview recommends it.

For a one-shot automation run (webhook, schedule) there is no next event at all: the evicted content is simply unreachable for the whole run.

## Observed in production (Luge, 2026-07-29)

An agent's `hubspot` call evicted (13.6k tokens). The model spent the rest of the turn hunting for `read_stored_result` through its discovery tools and the sandbox filesystem, found nothing, then **guessed at the evicted content — wrongly** (it mislabeled a customer message as internal, which in that workflow means silently dropping a customer reply). Reproduced twice on the same call.

## The fix

Inject `ToolEviction.tool_definition()` per round in `_prepare_round_context` when the store holds anything, deduped by name. One seam covers both loops (streaming `_ai_streaming.py:381` and non-streaming `_ai_generation.py:546`), and the dispatch table already accepts the call unconditionally (`_ai_tools.py` — `"read_stored_result"` is always registered), so visibility was the only missing half. When nothing was evicted, the round context is untouched.

`_eviction` is declared on `AIToolLoopRulesHost` / `AIToolLoopRulesMixin` the same way `_ai_resilience.py` already declares it.

## Tests

`TestEvictionToolAvailableMidLoop` in `tests/test_channels/test_ai_tool_loop.py`:
- after an eviction at round N, round N+1's context advertises `read_stored_result`; the call is channel-managed (user handler never sees it) and the paged content actually returns into the conversation — **fails on main, passes with the fix** (verified by stashing the src change);
- when nothing was evicted, no injection happens.

Full `tests/test_channels/` + eviction/streaming suites: 212 passed. Ruff clean, mypy clean on the touched module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)