### PR TITLE
feat(acp): preserve usage session and report provenance (RMK-171)

### DIFF
--- a/examples/acp_claude_code.py
+++ b/examples/acp_claude_code.py
@@ -202,8 +202,6 @@ async def main(args: argparse.Namespace) -> None:
         category=ChannelCategory.INTELLIGENCE,
     )
 
-    billed_so_far = 0.0
-
     @kit.hook(HookTrigger.ON_AI_RESPONSE, execution=HookExecution.ASYNC)
     async def turn_finished(event: Any, _ctx: Any) -> None:
         """What a host learns when the agent has finished answering.
@@ -214,34 +212,25 @@ async def main(args: argparse.Namespace) -> None:
         which is what makes post-processing (summaries, memory, metrics)
         possible for a conversation an agent held.
 
-        Priced from ``cost``, which ACP reports as the session's running
-        total — that one genuinely accumulates — so a turn's own price is the
-        difference from the last reading. RoomKit relays the figure without
-        differencing it, because which difference is wanted belongs to whoever
-        is counting; this is one of them.
-
-        The token counters explain the price rather than set it. A turn that
-        answers in three words still reports tens of thousands, nearly all of
-        it the agent's preamble and the project's context re-read from cache
-        at a fraction of a fresh token's price. Summing ``total_tokens`` over
-        a conversation therefore counts the same prefix once per turn and
-        means nothing in money.
+        ``cost`` is the session's announced running total, not a turn price.
+        The report identity and source travel separately in usage_metadata.
+        They allow a host to recognize a replay without inventing a delta.
         """
-        nonlocal billed_so_far
         spend = ""
         if event.usage:
             total = event.usage.get("cost")
             if total is not None:
-                turn_cost = total - billed_so_far
-                billed_so_far = total
-                spend += f" · {turn_cost:.4f} {event.usage.get('currency', '')}".rstrip()
+                spend += f" · session total {total:.4f} {event.usage.get('currency', '')}".rstrip()
             spend += (
-                f" · {event.usage.get('total_tokens', 0)} tokens"
-                f" ({event.usage.get('input_tokens', 0)} in"
-                f" / {event.usage.get('output_tokens', 0)} out"
-                f" / {event.usage.get('cached_read_tokens', 0)} cached)"
+                f" · {event.usage.get('total_tokens', '?')} tokens"
+                f" ({event.usage.get('input_tokens', '?')} in"
+                f" / {event.usage.get('output_tokens', '?')} out"
+                f" / {event.usage.get('cached_read_tokens', '?')} cached)"
             )
-        print(f"\n[turn] {event.tool_calls_count} tool call(s) · {event.latency_ms}ms{spend}\n")
+        session = event.usage_metadata.get("session_id", "unknown")
+        print(
+            f"\n[turn session={session}] {event.tool_calls_count} tool call(s) · {event.latency_ms}ms{spend}\n"
+        )
 
     async def switch_model(requested: str) -> None:
         """Handle ``/model`` here instead of letting it reach the agent.

--- a/src/roomkit/channels/_acp_client.py
+++ b/src/roomkit/channels/_acp_client.py
@@ -75,6 +75,9 @@ class _TurnState:
     context: dict[str, Any] = field(default_factory=dict)
     """Last context-window occupancy and running cost the agent announced."""
 
+    usage_metadata: dict[str, Any] = field(default_factory=dict)
+    """Snapshots of the source identities, independent of room/channel identity."""
+
     completed: bool = False
     """Whether the turn reached its terminal item without an error.
 
@@ -123,75 +126,6 @@ def _model_dump(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [_model_dump(item) for item in value]
     return value
-
-
-_TOKEN_FIELDS = (
-    "total_tokens",
-    "input_tokens",
-    "output_tokens",
-    "thought_tokens",
-    "cached_read_tokens",
-    "cached_write_tokens",
-)
-
-
-def _usage_tokens(usage: Any) -> dict[str, int]:
-    """Read the ``Usage`` an agent returns when a prompt ends.
-
-    Taken off the model by attribute rather than out of :func:`_model_dump`,
-    whose camelCase aliases would not sit beside the counters an in-process
-    provider reports under the same key.
-
-    Relayed exactly as the agent sent it. The ACP schema annotates these
-    fields as running session figures ("total input tokens across all turns")
-    while the reference agent fills them per prompt — measured against it,
-    ``cached_read_tokens`` is the whole prefix re-read on that turn, not a sum
-    over turns. RoomKit cannot tell the two apart from one reading, and
-    guessing wrong corrupts the number in the direction nobody can detect
-    downstream, so it does no arithmetic on them at all.
-    """
-    counters: dict[str, int] = {}
-    for name in _TOKEN_FIELDS:
-        value = getattr(usage, name, None)
-        if isinstance(value, int):
-            counters[name] = value
-    return counters
-
-
-def _usage_context(update: Any) -> dict[str, Any]:
-    """Read a usage notification: how full the context is, what it has cost.
-
-    A different quantity from the token counters above — ``used``/``size``
-    describe the window the session is living in, and ``cost`` is its running
-    total. These really are cumulative, and observably so: they climb turn
-    after turn.
-    """
-    context: dict[str, Any] = {}
-    used = getattr(update, "used", None)
-    if isinstance(used, int):
-        context["context_used"] = used
-    size = getattr(update, "size", None)
-    if isinstance(size, int):
-        context["context_size"] = size
-    cost = getattr(update, "cost", None)
-    amount = getattr(cost, "amount", None)
-    if isinstance(amount, (int, float)):
-        context["cost"] = float(amount)
-    currency = getattr(cost, "currency", None)
-    if isinstance(currency, str) and currency:
-        context["currency"] = currency
-    return context
-
-
-def _usage_report(tokens: dict[str, int], context: dict[str, Any]) -> dict[str, Any]:
-    """The accounting a finished turn carries: what the agent counted, and where.
-
-    Two readings side by side under distinct keys — the token counters from
-    the prompt's own response, and the session's context occupancy and running
-    cost. Both are the agent's figures, unaltered; see :func:`_usage_tokens`
-    for why nothing here is differenced.
-    """
-    return {**tokens, **context}
 
 
 def _config_values(options: Any) -> dict[str, str | bool]:

--- a/src/roomkit/channels/_acp_client.py
+++ b/src/roomkit/channels/_acp_client.py
@@ -78,6 +78,9 @@ class _TurnState:
     usage_metadata: dict[str, Any] = field(default_factory=dict)
     """Snapshots of the source identities, independent of room/channel identity."""
 
+    usage_finalized: bool = False
+    """The runner sealed its observations; later notifications stay ephemeral."""
+
     completed: bool = False
     """Whether the turn reached its terminal item without an error.
 

--- a/src/roomkit/channels/_acp_events.py
+++ b/src/roomkit/channels/_acp_events.py
@@ -21,8 +21,8 @@ from roomkit.channels._acp_client import (
 from roomkit.channels._acp_usage import (
     _apply_transport_usage,
     _observe_usage,
+    _report_context,
     _transport_usage,
-    _usage_context,
 )
 from roomkit.models.streaming import (
     ThinkingDeltaMarker,
@@ -32,6 +32,7 @@ from roomkit.models.streaming import (
 from roomkit.realtime.base import EphemeralEvent, EphemeralEventType
 
 if TYPE_CHECKING:
+    from roomkit.channels.acp_transport import ACPTransport
     from roomkit.realtime.base import RealtimeBackend
     from roomkit.tools.external import ExternalToolHandler
 
@@ -47,6 +48,7 @@ class ACPEventsMixin:
     _turns: dict[str, _TurnState]
     _session_rooms: dict[str, str]
     _session_options: dict[str, list[Any]]
+    _transport: ACPTransport
     _external_tool_handler: ExternalToolHandler | None
     _realtime: RealtimeBackend | None
 
@@ -109,7 +111,7 @@ class ACPEventsMixin:
         )
 
     async def _on_usage_update(self, session_id: str, update: Any) -> None:
-        envelope = _transport_usage(update)
+        envelope = _transport_usage(update) if self._transport.provides_usage_metadata else None
         report = (
             envelope.get("usage_report")
             if envelope is not None
@@ -118,13 +120,15 @@ class ACPEventsMixin:
             )
         )
         turn = self._turns.get(session_id)
-        if turn is not None and (envelope is None or envelope.get("session_id") == session_id):
+        if (
+            turn is not None
+            and not turn.usage_finalized
+            and (envelope is None or envelope.get("session_id") == session_id)
+        ):
             # Kept, not only announced: the end-of-turn report is the only
             # place this reaches a host that is not watching the ephemeral
             # stream.
-            turn.context = _usage_context(
-                report.get("update") if isinstance(report, Mapping) else None
-            )
+            turn.context = _report_context(report)
             if envelope is not None:
                 _apply_transport_usage(turn.usage_metadata, envelope, terminal=False)
             else:

--- a/src/roomkit/channels/_acp_events.py
+++ b/src/roomkit/channels/_acp_events.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Awaitable, Callable, Mapping
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from roomkit.channels._acp_client import (
@@ -16,6 +17,11 @@ from roomkit.channels._acp_client import (
     _result_text,
     _ToolState,
     _TurnState,
+)
+from roomkit.channels._acp_usage import (
+    _apply_transport_usage,
+    _observe_usage,
+    _transport_usage,
     _usage_context,
 )
 from roomkit.models.streaming import (
@@ -103,12 +109,26 @@ class ACPEventsMixin:
         )
 
     async def _on_usage_update(self, session_id: str, update: Any) -> None:
+        envelope = _transport_usage(update)
+        report = (
+            envelope.get("usage_report")
+            if envelope is not None
+            else _observe_usage(
+                update, _config_values(self._session_options.get(session_id)).get("model")
+            )
+        )
         turn = self._turns.get(session_id)
-        if turn is not None:
+        if turn is not None and (envelope is None or envelope.get("session_id") == session_id):
             # Kept, not only announced: the end-of-turn report is the only
             # place this reaches a host that is not watching the ephemeral
             # stream.
-            turn.context = _usage_context(update)
+            turn.context = _usage_context(
+                report.get("update") if isinstance(report, Mapping) else None
+            )
+            if envelope is not None:
+                _apply_transport_usage(turn.usage_metadata, envelope, terminal=False)
+            else:
+                turn.usage_metadata["usage_report"] = deepcopy(report)
         room_id = self._session_rooms.get(session_id)
         if room_id is None:
             return
@@ -119,6 +139,12 @@ class ACPEventsMixin:
                 "type": "acp_usage",
                 "session_id": session_id,
                 "usage": _model_dump(update),
+                "usage_metadata": envelope
+                if envelope is not None
+                else {
+                    "session_id": session_id,
+                    "usage_report": report,
+                },
             },
         )
 

--- a/src/roomkit/channels/_acp_usage.py
+++ b/src/roomkit/channels/_acp_usage.py
@@ -72,6 +72,11 @@ def _field(value: Any, name: str) -> Any:
     return value.get(name) if isinstance(value, Mapping) else getattr(value, name, None)
 
 
+def _report_context(report: Any) -> dict[str, Any]:
+    """Normalize the context/cost carried by a session observation."""
+    return _usage_context(_field(report, "update"))
+
+
 def _transport_usage(value: Any) -> dict[str, Any] | None:
     """Read the opt-in transport envelope, never arbitrary agent extensions."""
     meta = _field(value, "field_meta") or _field(value, "_meta")
@@ -85,6 +90,7 @@ _SESSION_IDENTITY_FIELDS = (
     "usage_protocol",
     "node_id",
     "agent_id",
+    "adapter_info",
 )
 _USAGE_IDENTITY_FIELDS = (
     *_SESSION_IDENTITY_FIELDS,

--- a/src/roomkit/channels/_acp_usage.py
+++ b/src/roomkit/channels/_acp_usage.py
@@ -1,0 +1,143 @@
+"""Normalization and provenance of ACP usage observations."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any
+from uuid import uuid4
+
+from roomkit.channels._acp_client import _model_dump
+
+_TOKEN_FIELDS = (
+    "total_tokens",
+    "input_tokens",
+    "output_tokens",
+    "thought_tokens",
+    "cached_read_tokens",
+    "cached_write_tokens",
+)
+
+
+def _usage_tokens(usage: Any) -> dict[str, int]:
+    """Read the ``Usage`` an agent returns when a prompt ends.
+
+    Taken off the model by attribute rather than out of :func:`_model_dump`,
+    whose camelCase aliases would not sit beside the counters an in-process
+    provider reports under the same key.
+
+    Relayed exactly as the agent sent it. The ACP schema annotates these
+    fields as running session figures ("total input tokens across all turns")
+    while the reference agent fills them per prompt — measured against it,
+    ``cached_read_tokens`` is the whole prefix re-read on that turn, not a sum
+    over turns. RoomKit cannot tell the two apart from one reading, and
+    guessing wrong corrupts the number in the direction nobody can detect
+    downstream, so it does no arithmetic on them at all.
+    """
+    counters: dict[str, int] = {}
+    for name in _TOKEN_FIELDS:
+        value = getattr(usage, name, None)
+        if isinstance(value, int):
+            counters[name] = value
+    return counters
+
+
+def _usage_context(update: Any) -> dict[str, Any]:
+    """Read a usage notification: how full the context is, what it has cost.
+
+    A different quantity from the token counters above — ``used``/``size``
+    describe the window the session is living in, and ``cost`` is its running
+    total. Occupancy/capacity can fall after compaction or reconfiguration;
+    neither is a count of tokens consumed by the prompt.
+    """
+    context: dict[str, Any] = {}
+    used = _field(update, "used")
+    if type(used) is int:
+        context["context_used"] = used
+    size = _field(update, "size")
+    if type(size) is int:
+        context["context_size"] = size
+    cost = _field(update, "cost")
+    amount = _field(cost, "amount")
+    if type(amount) in (int, float):
+        context["cost"] = float(amount)
+    currency = _field(cost, "currency")
+    if isinstance(currency, str) and currency:
+        context["currency"] = currency
+    return context
+
+
+def _field(value: Any, name: str) -> Any:
+    return value.get(name) if isinstance(value, Mapping) else getattr(value, name, None)
+
+
+def _transport_usage(value: Any) -> dict[str, Any] | None:
+    """Read the opt-in transport envelope, never arbitrary agent extensions."""
+    meta = _field(value, "field_meta") or _field(value, "_meta")
+    envelope = _field(meta, "roomkit.live/usage")
+    return deepcopy(dict(envelope)) if isinstance(envelope, Mapping) else None
+
+
+_SESSION_IDENTITY_FIELDS = (
+    "session_id",
+    "session_epoch",
+    "usage_protocol",
+    "node_id",
+    "agent_id",
+)
+_USAGE_IDENTITY_FIELDS = (
+    *_SESSION_IDENTITY_FIELDS,
+    "result_id",
+    "turn_id",
+    "generation",
+    "replayed",
+)
+
+
+def _apply_transport_usage(
+    metadata: dict[str, Any],
+    envelope: dict[str, Any],
+    *,
+    terminal: bool = True,
+) -> None:
+    """A terminal snapshot is authoritative, including an absent report.
+
+    Recovery can return another session's result. Never pair its counters
+    with the current session's live cost or model. A report's source_result_id
+    is its origin, even when it differs from this response's result_id.
+    """
+    # A notification's result ID describes its origin, not the active prompt.
+    # Only a prompt response can establish the result identity at the root.
+    identities = _USAGE_IDENTITY_FIELDS if terminal else _SESSION_IDENTITY_FIELDS
+    for key in (*identities, "usage_report"):
+        metadata.pop(key, None)
+        if key in envelope:
+            metadata[key] = deepcopy(envelope[key])
+    metadata["identity_source"] = "transport"
+
+
+def _observe_usage(update: Any, model: str | bool | None) -> dict[str, Any]:
+    """Identify a local receipt without inventing a source prompt or durability."""
+    report: dict[str, Any] = {
+        "report_id": uuid4().hex,
+        "identity_source": "roomkit",
+        "observed_at_ms": time.time_ns() // 1_000_000,
+        "source": "session/update",
+        "scope": "session",
+        "update": deepcopy(_model_dump(update)),
+    }
+    if isinstance(model, str):
+        report["model_at_observation"] = model
+    return report
+
+
+def _usage_report(tokens: dict[str, int], context: dict[str, Any]) -> dict[str, Any]:
+    """The accounting a finished turn carries: what the agent counted, and where.
+
+    Two readings side by side under distinct keys — the token counters from
+    the prompt's own response, and the session's context occupancy and running
+    cost. Both are the agent's figures, unaltered; see :func:`_usage_tokens`
+    for why nothing here is differenced.
+    """
+    return {**tokens, **context}

--- a/src/roomkit/channels/acp.py
+++ b/src/roomkit/channels/acp.py
@@ -18,6 +18,7 @@ import contextlib
 import logging
 import time
 from collections.abc import AsyncIterator, Mapping, Sequence
+from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -42,8 +43,8 @@ from roomkit.channels._acp_context import (
 from roomkit.channels._acp_events import ACPEventsMixin
 from roomkit.channels._acp_usage import (
     _apply_transport_usage,
+    _report_context,
     _transport_usage,
-    _usage_context,
     _usage_report,
     _usage_tokens,
 )
@@ -559,6 +560,8 @@ class ACPChannel(ACPConnectionMixin, ACPEventsMixin, Channel):
                     "prompt": prompt_source,
                 },
             )
+            if self._agent_info is not None:
+                turn.usage_metadata["adapter_info"] = deepcopy(self._agent_info)
             self._turns[session_id] = turn
             catch_up = room_context_block(
                 context,
@@ -708,7 +711,9 @@ class ACPChannel(ACPConnectionMixin, ACPEventsMixin, Channel):
             if stop_reason and stop_reason != _CLEAN_STOP_REASON:
                 acp_meta["stop_reason"] = stop_reason
             await self._drain_session_updates(session_id)
-            envelope = _transport_usage(response)
+            envelope = (
+                _transport_usage(response) if self._transport.provides_usage_metadata else None
+            )
             if envelope is not None:
                 _apply_transport_usage(turn.usage_metadata, envelope)
                 # The model of a recovered result is not the model we just
@@ -717,13 +722,13 @@ class ACPChannel(ACPConnectionMixin, ACPEventsMixin, Channel):
                 if isinstance(envelope.get("model"), str):
                     turn.usage_metadata["prompt"]["model"] = envelope["model"]
                 report = turn.usage_metadata.get("usage_report")
-                turn.context = _usage_context(
-                    report.get("update") if isinstance(report, Mapping) else None
-                )
+                turn.context = _report_context(report)
         except BaseException as exc:
             # The prompt never returned, so no stop reason exists to record:
             # the turn ended on the way, and that is the fact to carry.
             acp_meta["interrupted"] = True
+            turn.usage_finalized = True
             turn.queue.put_nowait(_TurnDone(error=exc))
         else:
+            turn.usage_finalized = True
             turn.queue.put_nowait(_TurnDone())

--- a/src/roomkit/channels/acp.py
+++ b/src/roomkit/channels/acp.py
@@ -31,8 +31,6 @@ from roomkit.channels._acp_client import (
     _model_dump,
     _TurnDone,
     _TurnState,
-    _usage_report,
-    _usage_tokens,
 )
 from roomkit.channels._acp_context import (
     ACPContextContributor,
@@ -42,6 +40,13 @@ from roomkit.channels._acp_context import (
     room_context_block,
 )
 from roomkit.channels._acp_events import ACPEventsMixin
+from roomkit.channels._acp_usage import (
+    _apply_transport_usage,
+    _transport_usage,
+    _usage_context,
+    _usage_report,
+    _usage_tokens,
+)
 from roomkit.channels.acp_transport import ACPTransport, StdioACPTransport
 from roomkit.channels.base import Channel
 from roomkit.models.channel import ChannelBinding, ChannelCapabilities, ChannelOutput
@@ -540,7 +545,20 @@ class ACPChannel(ACPConnectionMixin, ACPEventsMixin, Channel):
         async with self._room_turn_lock(room_id):
             connection = await self._ensure_connection()
             session_id = await self._session_for(room_id, connection)
-            turn = _TurnState(room_id=room_id)
+            prompt_source: dict[str, Any] = {"source": "session/prompt", "scope": "unspecified"}
+            model = self.session_config(room_id).get("model")
+            if isinstance(model, str):
+                prompt_source["model_at_start"] = model
+            turn = _TurnState(
+                room_id=room_id,
+                usage_metadata={
+                    "protocol": "acp",
+                    "transport": self._transport.name,
+                    "session_id": session_id,
+                    "event_id": event_id,
+                    "prompt": prompt_source,
+                },
+            )
             self._turns[session_id] = turn
             catch_up = room_context_block(
                 context,
@@ -637,6 +655,7 @@ class ACPChannel(ACPConnectionMixin, ACPEventsMixin, Channel):
                     room_id=turn.room_id,
                     tool_calls_count=len(turn.tools),
                     usage=_usage_report(turn.tokens, turn.context),
+                    usage_metadata=turn.usage_metadata,
                     latency_ms=int((time.monotonic() - turn.started_at) * 1000),
                     streaming=True,
                 )
@@ -684,9 +703,23 @@ class ACPChannel(ACPConnectionMixin, ACPEventsMixin, Channel):
             # the agent did not name stays unwritten rather than being read as
             # either outcome.
             stop_reason = getattr(response, "stop_reason", None)
+            if stop_reason:
+                turn.usage_metadata["prompt"]["stop_reason"] = stop_reason
             if stop_reason and stop_reason != _CLEAN_STOP_REASON:
                 acp_meta["stop_reason"] = stop_reason
             await self._drain_session_updates(session_id)
+            envelope = _transport_usage(response)
+            if envelope is not None:
+                _apply_transport_usage(turn.usage_metadata, envelope)
+                # The model of a recovered result is not the model we just
+                # asked. Only the transport can supply that historical fact.
+                turn.usage_metadata["prompt"].pop("model_at_start", None)
+                if isinstance(envelope.get("model"), str):
+                    turn.usage_metadata["prompt"]["model"] = envelope["model"]
+                report = turn.usage_metadata.get("usage_report")
+                turn.context = _usage_context(
+                    report.get("update") if isinstance(report, Mapping) else None
+                )
         except BaseException as exc:
             # The prompt never returned, so no stop reason exists to record:
             # the turn ended on the way, and that is the fact to carry.

--- a/src/roomkit/channels/acp_transport.py
+++ b/src/roomkit/channels/acp_transport.py
@@ -61,10 +61,11 @@ class ACPTransport(ABC):
     Implement this to reach an agent the channel cannot spawn itself — one
     running on another machine, or behind a relay that carries its stdio.
 
-    Usage provenance is an optional extension of the connection's SDK models:
+    Usage provenance is an opt-in extension of the connection's SDK models
+    (see :attr:`provides_usage_metadata`):
     ``PromptResponse._meta["roomkit.live/usage"]`` (``field_meta`` in Python)
     carries ``session_id``, ``session_epoch``, ``usage_protocol``, ``node_id``,
-    ``agent_id``, ``result_id``, ``turn_id``, ``generation`` and ``replayed``
+    ``agent_id``, ``adapter_info``, ``result_id``, ``turn_id``, ``generation`` and ``replayed``
     when known. ``model`` is the model of that prompt, if known. Do not infer
     any of them from the room or current connection during recovery.
 
@@ -77,9 +78,20 @@ class ACPTransport(ABC):
     report. Replay must preserve the original identities and timestamps.
 
     The transport owns the authenticated node/adapter identity and must
-    validate the envelope before exposing it. Old connections may omit the
+    validate the envelope before exposing it. Metadata is reported provenance,
+    never an authorization credential. Old connections may omit the
     extension entirely. No additional abstract methods are required.
     """
+
+    @property
+    def provides_usage_metadata(self) -> bool:
+        """Whether this transport supplies validated usage provenance.
+
+        Override only when the transport owns the ``roomkit.live/usage``
+        envelope, validating or replacing peer-supplied values. By default,
+        peer ACP metadata cannot claim authenticated transport identities.
+        """
+        return False
 
     @property
     @abstractmethod

--- a/src/roomkit/channels/acp_transport.py
+++ b/src/roomkit/channels/acp_transport.py
@@ -60,6 +60,25 @@ class ACPTransport(ABC):
 
     Implement this to reach an agent the channel cannot spawn itself — one
     running on another machine, or behind a relay that carries its stdio.
+
+    Usage provenance is an optional extension of the connection's SDK models:
+    ``PromptResponse._meta["roomkit.live/usage"]`` (``field_meta`` in Python)
+    carries ``session_id``, ``session_epoch``, ``usage_protocol``, ``node_id``,
+    ``agent_id``, ``result_id``, ``turn_id``, ``generation`` and ``replayed``
+    when known. ``model`` is the model of that prompt, if known. Do not infer
+    any of them from the room or current connection during recovery.
+
+    ``usage_report`` is the last session observation, with ``report_id``,
+    ``observed_at_ms``, ``source="session/update"``, ``scope="session"``,
+    optional ``source_result_id``, and the raw ACP ``update``. It stays
+    separate from ``PromptResponse.usage`` token counters. Forward the same
+    envelope on a ``UsageUpdate`` to preserve live report identities too.
+    A terminal envelope replaces live observations, including when it has no
+    report. Replay must preserve the original identities and timestamps.
+
+    The transport owns the authenticated node/adapter identity and must
+    validate the envelope before exposing it. Old connections may omit the
+    extension entirely. No additional abstract methods are required.
     """
 
     @property

--- a/src/roomkit/models/tool_call.py
+++ b/src/roomkit/models/tool_call.py
@@ -142,6 +142,14 @@ class AIResponseEvent:
     produced no text.
     """
 
+    usage_metadata: dict[str, Any] = field(default_factory=dict)
+    """Optional provenance and scope of the provider's usage observations.
+
+    ACP includes the native session, prompt source and session usage report.
+    These are observations, not a price or a claim that generation succeeded.
+    Existing providers and consumers can leave this empty.
+    """
+
 
 # Callback type for AI response observation (fire-and-forget).
 AfterResponseCallback = Callable[["AIResponseEvent"], Awaitable[None]]

--- a/tests/test_channels/test_acp_usage.py
+++ b/tests/test_channels/test_acp_usage.py
@@ -1,0 +1,360 @@
+"""ACP usage provenance through the transport and framework hook boundaries."""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from copy import deepcopy
+from typing import Any
+
+import acp
+import pytest
+from acp.schema import (
+    ConfigOptionUpdate,
+    Cost,
+    NewSessionResponse,
+    PromptResponse,
+    Usage,
+    UsageUpdate,
+)
+
+from roomkit import ACPChannel, AIResponseEvent, HookExecution, HookTrigger, RoomKit
+from roomkit.models.delivery import InboundMessage
+from roomkit.models.event import TextContent
+from roomkit.providers.ai.base import ProviderError
+from roomkit.realtime.memory import InMemoryRealtime
+from tests.conftest import make_event
+from tests.test_channels.test_acp import (
+    TestEndOfTurnReport as _EndOfTurnReport,
+)
+from tests.test_channels.test_acp import (
+    _binding,
+    _channel,
+    _context,
+    _InProcessEchoAgent,
+    _model_option,
+    _prompt,
+    _SocketPairTransport,
+)
+from tests.test_framework import SimpleChannel
+
+
+def _envelope(session: str = "original-session") -> dict[str, Any]:
+    return {
+        "usage_protocol": 1,
+        "session_id": session,
+        "session_epoch": "epoch-1",
+        "node_id": "node-1",
+        "agent_id": "adapter-1",
+        "result_id": "result-2",
+        "turn_id": "turn-2",
+        "generation": 0,
+        "replayed": True,
+        "usage_report": {
+            "report_id": "report-1",
+            "observed_at_ms": 1234,
+            "source": "session/update",
+            "scope": "session",
+            "source_result_id": "result-1",
+            "update": {
+                "sessionUpdate": "usage_update",
+                "used": 0,
+                "size": 100,
+                "cost": {"amount": 0, "currency": "USD"},
+            },
+        },
+    }
+
+
+def _update(**kwargs: Any) -> UsageUpdate:
+    return UsageUpdate(session_update="usage_update", used=0, size=100, **kwargs)
+
+
+class TestUsageProvenance:
+    async def test_model_snapshots_and_no_carry_into_next_prompt(self, tmp_path: Any) -> None:
+        channel, connection, _ = _channel(tmp_path, emit_updates=False)
+        reports = _EndOfTurnReport._capture(channel)
+        realtime = InMemoryRealtime()
+        channel._realtime = realtime
+        notices: list[Any] = []
+
+        async def capture(event: Any) -> None:
+            if event.data.get("type") == "acp_usage":
+                notices.append(event.data)
+
+        await realtime.subscribe_to_room("room-1", capture)
+
+        async def prompt(session_id: str, prompt: Any, **kwargs: Any) -> PromptResponse:
+            await connection.client.session_update(
+                session_id, _update(cost=Cost(amount=0, currency="USD"))
+            )
+            await connection.client.session_update(
+                session_id,
+                ConfigOptionUpdate(
+                    session_update="config_option_update", config_options=[_model_option("sonnet")]
+                ),
+            )
+            return PromptResponse(
+                stop_reason="end_turn",
+                usage=Usage(input_tokens=0, output_tokens=0, total_tokens=0),
+            )
+
+        connection.prompt = prompt
+        first = make_event(body="first")
+        await _prompt(channel, first, _context())
+        observation = reports[0].usage_metadata
+        assert observation["session_id"] == "session-1"
+        assert observation["event_id"] == first.id
+        assert observation["prompt"] == {
+            "source": "session/prompt",
+            "scope": "unspecified",
+            "model_at_start": "opus",
+            "stop_reason": "end_turn",
+        }
+        assert observation["usage_report"]["model_at_observation"] == "opus"
+        assert "source_result_id" not in observation["usage_report"]
+        assert reports[0].usage["cost"] == reports[0].usage["input_tokens"] == 0
+        assert (
+            notices[0]["usage_metadata"]["usage_report"]["report_id"]
+            == observation["usage_report"]["report_id"]
+        )
+
+        # A notification between prompts remains observable but cannot become
+        # the next prompt's report, even though the session is unchanged.
+        await connection.client.session_update(
+            "session-1", _update(cost=Cost(amount=5, currency="EUR"))
+        )
+
+        async def empty(session_id: str, prompt: Any, **kwargs: Any) -> PromptResponse:
+            return PromptResponse(stop_reason="end_turn")
+
+        connection.prompt = empty
+        await _prompt(channel, make_event(body="second"), _context())
+        assert reports[1].usage == {}
+        assert "usage_report" not in reports[1].usage_metadata
+        assert reports[1].usage_metadata["prompt"]["model_at_start"] == "sonnet"
+        assert observation["usage_report"]["update"]["cost"]["amount"] == 0
+        await channel.close()
+        await realtime.close()
+
+    @pytest.mark.parametrize("with_report", [False, True])
+    async def test_recovered_snapshot_is_authoritative_and_repeatable(
+        self, tmp_path: Any, with_report: bool
+    ) -> None:
+        channel, connection, _ = _channel(tmp_path, emit_updates=False)
+        reports = _EndOfTurnReport._capture(channel)
+        envelope = _envelope()
+        if not with_report:
+            envelope.pop("usage_report")
+
+        async def recovered(session_id: str, prompt: Any, **kwargs: Any) -> PromptResponse:
+            await connection.client.session_update(
+                session_id, _update(cost=Cost(amount=99, currency="EUR"))
+            )
+            return PromptResponse(
+                stop_reason="cancelled",
+                usage=Usage(input_tokens=1, output_tokens=2, total_tokens=3),
+                field_meta={"roomkit.live/usage": envelope},
+            )
+
+        connection.prompt = recovered
+        for body in ("recover", "replay"):
+            await _prompt(channel, make_event(body=body), _context())
+        for event in reports:
+            meta = event.usage_metadata
+            assert meta["session_id"] == "original-session"
+            assert meta["session_epoch"] == "epoch-1"
+            assert meta["generation"] == 0
+            assert meta["result_id"] == "result-2"
+            assert meta["prompt"] == {
+                "source": "session/prompt",
+                "scope": "unspecified",
+                "stop_reason": "cancelled",
+            }
+            assert event.usage["input_tokens"] == 1
+            if with_report:
+                assert meta["usage_report"] == envelope["usage_report"]
+                assert meta["usage_report"]["source_result_id"] != meta["result_id"]
+                assert event.usage["cost"] == 0
+                assert event.usage["currency"] == "USD"
+            else:
+                assert "usage_report" not in meta
+                assert "cost" not in event.usage
+        envelope["session_id"] = "mutated"
+        assert reports[0].usage_metadata["session_id"] == "original-session"
+        await channel.close()
+
+    async def test_wrong_session_notification_does_not_poison_active_turn(
+        self, tmp_path: Any
+    ) -> None:
+        channel, connection, _ = _channel(tmp_path, emit_updates=False)
+        reports = _EndOfTurnReport._capture(channel)
+
+        async def prompt(session_id: str, prompt: Any, **kwargs: Any) -> PromptResponse:
+            await connection.client.session_update(
+                session_id, _update(field_meta={"roomkit.live/usage": _envelope("old-session")})
+            )
+            return PromptResponse(stop_reason="end_turn")
+
+        connection.prompt = prompt
+        await _prompt(channel, make_event(body="new session"), _context())
+        assert reports[0].usage == {}
+        assert "usage_report" not in reports[0].usage_metadata
+        assert reports[0].usage_metadata["session_id"] == "session-1"
+        await channel.close()
+
+    async def test_late_durable_report_preserves_origin_without_claiming_prompt(
+        self, tmp_path: Any
+    ) -> None:
+        channel, connection, _ = _channel(tmp_path, emit_updates=False)
+        reports = _EndOfTurnReport._capture(channel)
+        envelope = _envelope("session-1")
+
+        async def prompt(session_id: str, prompt: Any, **kwargs: Any) -> PromptResponse:
+            await connection.client.session_update(
+                session_id, _update(field_meta={"roomkit.live/usage": envelope})
+            )
+            return PromptResponse(stop_reason="end_turn")
+
+        connection.prompt = prompt
+        await _prompt(channel, make_event(body="new prompt"), _context())
+        meta = reports[0].usage_metadata
+        assert meta["usage_report"]["source_result_id"] == "result-1"
+        assert meta["usage_report"]["report_id"] == "report-1"
+        assert "result_id" not in meta
+        assert meta["session_epoch"] == "epoch-1"
+        await channel.close()
+
+    async def test_same_native_id_after_reset_keeps_distinct_epochs(self, tmp_path: Any) -> None:
+        channel, connection, _ = _channel(tmp_path, emit_updates=False)
+        reports = _EndOfTurnReport._capture(channel)
+        envelope = _envelope("reused-native-id")
+
+        async def prompt(session_id: str, prompt: Any, **kwargs: Any) -> PromptResponse:
+            return PromptResponse(
+                stop_reason="end_turn", field_meta={"roomkit.live/usage": envelope}
+            )
+
+        connection.prompt = prompt
+        await _prompt(channel, make_event(body="first"), _context())
+        await channel.close_session("room-1")
+        envelope["session_epoch"] = "epoch-2"
+        await _prompt(channel, make_event(body="second"), _context())
+        assert [e.usage_metadata["session_epoch"] for e in reports] == ["epoch-1", "epoch-2"]
+        assert all(e.usage_metadata["session_id"] == "reused-native-id" for e in reports)
+        await channel.close()
+
+    @pytest.mark.parametrize("failure", ["error", "abandon"])
+    async def test_interrupted_usage_remains_observable_without_response(
+        self, tmp_path: Any, failure: str
+    ) -> None:
+        channel, connection, _ = _channel(tmp_path, emit_updates=False)
+        reports = _EndOfTurnReport._capture(channel)
+        realtime = InMemoryRealtime()
+        channel._realtime = realtime
+        notices: list[Any] = []
+
+        async def capture(event: Any) -> None:
+            if event.data.get("type") == "acp_usage":
+                notices.append(event.data)
+
+        await realtime.subscribe_to_room("room-1", capture)
+
+        async def interrupted(session_id: str, prompt: Any, **kwargs: Any) -> PromptResponse:
+            await connection.client.session_update(session_id, _update())
+            if failure == "error":
+                raise RuntimeError("lost agent")
+            await connection.client.session_update(
+                session_id, acp.update_agent_message_text("partial")
+            )
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+        connection.prompt = interrupted
+        output = await channel.on_event(make_event(body="go"), _binding(), _context())
+        if failure == "error":
+            with pytest.raises(ProviderError):
+                _ = [chunk async for chunk in output.response_stream]
+        else:
+            assert await anext(output.response_stream) == "partial"
+            await output.response_stream.aclose()
+        await asyncio.sleep(0)
+        assert reports == []
+        assert notices[0]["usage_metadata"]["session_id"] == "session-1"
+        assert "cost" not in notices[0]["usage_metadata"]["usage_report"]["update"]
+        await channel.close()
+        await realtime.close()
+
+
+class _UsageAgent(_InProcessEchoAgent):
+    def __init__(self, envelope: dict[str, Any]) -> None:
+        self.envelope = envelope
+
+    async def new_session(self, cwd: str, **kwargs: Any) -> NewSessionResponse:
+        return NewSessionResponse(session_id=self.envelope["session_id"])
+
+    async def prompt(self, session_id: str, prompt: list[Any], **kwargs: Any) -> PromptResponse:
+        await self.conn.session_update(
+            session_id, _update(field_meta={"roomkit.live/usage": self.envelope})
+        )
+        await self.conn.session_update(session_id, acp.update_agent_message_text("answer"))
+        return PromptResponse(
+            stop_reason="end_turn",
+            usage=Usage(input_tokens=2, output_tokens=3, total_tokens=5),
+            field_meta={"roomkit.live/usage": self.envelope},
+        )
+
+
+async def test_two_real_sdk_sessions_in_one_room_reach_framework_hooks(tmp_path: Any) -> None:
+    """Real JSON-RPC/SDK models, custom transports, and registered RoomKit hook."""
+    kit = RoomKit()
+    reports: list[AIResponseEvent] = []
+    servers: list[Any] = []
+    writers: list[Any] = []
+    received = asyncio.Event()
+
+    @kit.hook(HookTrigger.ON_AI_RESPONSE, execution=HookExecution.ASYNC)
+    async def observe(event: AIResponseEvent, ctx: Any) -> None:
+        reports.append(event)
+        if len(reports) == 2:
+            received.set()
+
+    try:
+        kit.register_channel(SimpleChannel("sms"))
+        await kit.create_room(room_id="room-1")
+        await kit.attach_channel("room-1", "sms")
+        for name in ("one", "two"):
+            left, right = socket.socketpair()
+            ar, aw = await asyncio.open_connection(sock=left)
+            cr, cw = await asyncio.open_connection(sock=right)
+            writers.append(aw)
+            envelope = deepcopy(_envelope(f"{name}-session"))
+            envelope["agent_id"] = name
+            servers.append(asyncio.create_task(acp.run_agent(_UsageAgent(envelope), aw, ar)))
+            kit.register_channel(
+                ACPChannel(name, cwd=tmp_path, transport=_SocketPairTransport(cr, cw))
+            )
+            await kit.attach_channel("room-1", name)
+        result = await kit.process_inbound(
+            InboundMessage(channel_id="sms", sender_id="user", content=TextContent(body="go"))
+        )
+        assert result.error is None
+        await asyncio.wait_for(received.wait(), 2)
+        assert {event.usage_metadata["session_id"] for event in reports} == {
+            "one-session",
+            "two-session",
+        }
+        for event in reports:
+            assert event.room_id == "room-1"
+            assert event.usage_metadata["agent_id"] == event.channel_id
+            assert event.usage_metadata["transport"] == "socketpair"
+            assert event.usage_metadata["usage_report"]["report_id"] == "report-1"
+            assert event.usage["input_tokens"] == 2
+            assert event.usage["cost"] == 0
+    finally:
+        await kit.close()
+        for task in servers:
+            task.cancel()
+        await asyncio.gather(*servers, return_exceptions=True)
+        for writer in writers:
+            writer.close()

--- a/tests/test_channels/test_acp_usage.py
+++ b/tests/test_channels/test_acp_usage.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import socket
-from copy import deepcopy
 from typing import Any
 
 import acp
@@ -12,15 +10,12 @@ import pytest
 from acp.schema import (
     ConfigOptionUpdate,
     Cost,
-    NewSessionResponse,
     PromptResponse,
     Usage,
     UsageUpdate,
 )
 
-from roomkit import ACPChannel, AIResponseEvent, HookExecution, HookTrigger, RoomKit
-from roomkit.models.delivery import InboundMessage
-from roomkit.models.event import TextContent
+from roomkit import ACPChannel
 from roomkit.providers.ai.base import ProviderError
 from roomkit.realtime.memory import InMemoryRealtime
 from tests.conftest import make_event
@@ -29,14 +24,26 @@ from tests.test_channels.test_acp import (
 )
 from tests.test_channels.test_acp import (
     _binding,
-    _channel,
     _context,
-    _InProcessEchoAgent,
+    _FakeACPConnection,
+    _FakeTransport,
     _model_option,
     _prompt,
-    _SocketPairTransport,
 )
-from tests.test_framework import SimpleChannel
+
+
+class _UsageTransport(_FakeTransport):
+    @property
+    def provides_usage_metadata(self) -> bool:
+        return True
+
+
+def _channel(tmp_path: Any, *, emit_updates: bool = False) -> tuple[ACPChannel, Any, Any]:
+    connection = _FakeACPConnection(None, emit_updates=emit_updates)
+    transport = _UsageTransport(connection)
+    channel = ACPChannel("acp-agent", transport=transport, cwd=tmp_path)
+    connection.client = channel._client
+    return channel, connection, transport
 
 
 def _envelope(session: str = "original-session") -> dict[str, Any]:
@@ -46,6 +53,7 @@ def _envelope(session: str = "original-session") -> dict[str, Any]:
         "session_epoch": "epoch-1",
         "node_id": "node-1",
         "agent_id": "adapter-1",
+        "adapter_info": '{"name":"test-adapter","version":"1.0"}',
         "result_id": "result-2",
         "turn_id": "turn-2",
         "generation": 0,
@@ -105,6 +113,7 @@ class TestUsageProvenance:
         observation = reports[0].usage_metadata
         assert observation["session_id"] == "session-1"
         assert observation["event_id"] == first.id
+        assert observation["adapter_info"]["name"] == "fake-agent"
         assert observation["prompt"] == {
             "source": "session/prompt",
             "scope": "unspecified",
@@ -164,6 +173,7 @@ class TestUsageProvenance:
             meta = event.usage_metadata
             assert meta["session_id"] == "original-session"
             assert meta["session_epoch"] == "epoch-1"
+            assert meta["adapter_info"] == envelope["adapter_info"]
             assert meta["generation"] == 0
             assert meta["result_id"] == "result-2"
             assert meta["prompt"] == {
@@ -284,77 +294,3 @@ class TestUsageProvenance:
         assert "cost" not in notices[0]["usage_metadata"]["usage_report"]["update"]
         await channel.close()
         await realtime.close()
-
-
-class _UsageAgent(_InProcessEchoAgent):
-    def __init__(self, envelope: dict[str, Any]) -> None:
-        self.envelope = envelope
-
-    async def new_session(self, cwd: str, **kwargs: Any) -> NewSessionResponse:
-        return NewSessionResponse(session_id=self.envelope["session_id"])
-
-    async def prompt(self, session_id: str, prompt: list[Any], **kwargs: Any) -> PromptResponse:
-        await self.conn.session_update(
-            session_id, _update(field_meta={"roomkit.live/usage": self.envelope})
-        )
-        await self.conn.session_update(session_id, acp.update_agent_message_text("answer"))
-        return PromptResponse(
-            stop_reason="end_turn",
-            usage=Usage(input_tokens=2, output_tokens=3, total_tokens=5),
-            field_meta={"roomkit.live/usage": self.envelope},
-        )
-
-
-async def test_two_real_sdk_sessions_in_one_room_reach_framework_hooks(tmp_path: Any) -> None:
-    """Real JSON-RPC/SDK models, custom transports, and registered RoomKit hook."""
-    kit = RoomKit()
-    reports: list[AIResponseEvent] = []
-    servers: list[Any] = []
-    writers: list[Any] = []
-    received = asyncio.Event()
-
-    @kit.hook(HookTrigger.ON_AI_RESPONSE, execution=HookExecution.ASYNC)
-    async def observe(event: AIResponseEvent, ctx: Any) -> None:
-        reports.append(event)
-        if len(reports) == 2:
-            received.set()
-
-    try:
-        kit.register_channel(SimpleChannel("sms"))
-        await kit.create_room(room_id="room-1")
-        await kit.attach_channel("room-1", "sms")
-        for name in ("one", "two"):
-            left, right = socket.socketpair()
-            ar, aw = await asyncio.open_connection(sock=left)
-            cr, cw = await asyncio.open_connection(sock=right)
-            writers.append(aw)
-            envelope = deepcopy(_envelope(f"{name}-session"))
-            envelope["agent_id"] = name
-            servers.append(asyncio.create_task(acp.run_agent(_UsageAgent(envelope), aw, ar)))
-            kit.register_channel(
-                ACPChannel(name, cwd=tmp_path, transport=_SocketPairTransport(cr, cw))
-            )
-            await kit.attach_channel("room-1", name)
-        result = await kit.process_inbound(
-            InboundMessage(channel_id="sms", sender_id="user", content=TextContent(body="go"))
-        )
-        assert result.error is None
-        await asyncio.wait_for(received.wait(), 2)
-        assert {event.usage_metadata["session_id"] for event in reports} == {
-            "one-session",
-            "two-session",
-        }
-        for event in reports:
-            assert event.room_id == "room-1"
-            assert event.usage_metadata["agent_id"] == event.channel_id
-            assert event.usage_metadata["transport"] == "socketpair"
-            assert event.usage_metadata["usage_report"]["report_id"] == "report-1"
-            assert event.usage["input_tokens"] == 2
-            assert event.usage["cost"] == 0
-    finally:
-        await kit.close()
-        for task in servers:
-            task.cancel()
-        await asyncio.gather(*servers, return_exceptions=True)
-        for writer in writers:
-            writer.close()

--- a/tests/test_channels/test_acp_usage_boundaries.py
+++ b/tests/test_channels/test_acp_usage_boundaries.py
@@ -1,0 +1,146 @@
+"""A terminal usage report is immutable while the stream consumer catches up."""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from copy import deepcopy
+from typing import Any
+
+import acp
+import pytest
+from acp.schema import Cost, NewSessionResponse, PromptResponse, Usage
+
+from roomkit import ACPChannel, AIResponseEvent, HookExecution, HookTrigger, RoomKit
+from roomkit.models.delivery import InboundMessage
+from roomkit.models.event import TextContent
+from tests.conftest import make_event
+from tests.test_channels.test_acp import TestEndOfTurnReport as _EndOfTurnReport
+from tests.test_channels.test_acp import _InProcessEchoAgent, _SocketPairTransport
+from tests.test_channels.test_acp_usage import _binding, _channel, _context, _envelope, _update
+from tests.test_framework import SimpleChannel
+
+
+@pytest.mark.parametrize("transport_report", [True, False])
+async def test_late_notification_cannot_overwrite_terminal_snapshot(
+    tmp_path: Any, transport_report: bool
+) -> None:
+    channel, connection, _ = _channel(tmp_path)
+    reports = _EndOfTurnReport._capture(channel)
+    envelope = _envelope()
+
+    async def recovered(session_id: str, prompt: Any, **kwargs: Any) -> PromptResponse:
+        await connection.client.session_update(session_id, acp.update_agent_message_text("answer"))
+        return PromptResponse(stop_reason="end_turn", field_meta={"roomkit.live/usage": envelope})
+
+    connection.prompt = recovered
+    output = await channel.on_event(make_event(body="recover"), _binding(), _context())
+    stream = output.response_stream
+    assert await anext(stream) == "answer"
+    await channel._turns["session-1"].runner
+    # The terminal result is queued, but the consumer has not read it yet.
+    late_meta = {"roomkit.live/usage": _envelope("session-1")} if transport_report else None
+    await connection.client.session_update(
+        "session-1", _update(cost=Cost(amount=99, currency="EUR"), field_meta=late_meta)
+    )
+    assert [chunk async for chunk in stream] == []
+    assert reports[0].usage_metadata["session_id"] == "original-session"
+    assert reports[0].usage_metadata["usage_report"] == envelope["usage_report"]
+    assert reports[0].usage["cost"] == 0
+    assert reports[0].usage["currency"] == "USD"
+    await channel.close()
+
+
+class _UsageSocketPairTransport(_SocketPairTransport):
+    @property
+    def provides_usage_metadata(self) -> bool:
+        return True
+
+
+class _UsageAgent(_InProcessEchoAgent):
+    def __init__(self, envelope: dict[str, Any]) -> None:
+        self.envelope = envelope
+
+    async def new_session(self, cwd: str, **kwargs: Any) -> NewSessionResponse:
+        return NewSessionResponse(session_id=self.envelope["session_id"])
+
+    async def prompt(self, session_id: str, prompt: list[Any], **kwargs: Any) -> PromptResponse:
+        await self.conn.session_update(
+            session_id, _update(field_meta={"roomkit.live/usage": self.envelope})
+        )
+        await self.conn.session_update(session_id, acp.update_agent_message_text("answer"))
+        return PromptResponse(
+            stop_reason="end_turn",
+            usage=Usage(input_tokens=2, output_tokens=3, total_tokens=5),
+            field_meta={"roomkit.live/usage": self.envelope},
+        )
+
+
+@pytest.mark.parametrize("trusted", [True, False])
+async def test_two_real_sdk_sessions_in_one_room_reach_framework_hooks(
+    tmp_path: Any, trusted: bool
+) -> None:
+    """Real JSON-RPC/SDK models, custom transports, and registered RoomKit hook."""
+    kit = RoomKit()
+    reports: list[AIResponseEvent] = []
+    servers: list[Any] = []
+    writers: list[Any] = []
+    received = asyncio.Event()
+
+    @kit.hook(HookTrigger.ON_AI_RESPONSE, execution=HookExecution.ASYNC)
+    async def observe(event: AIResponseEvent, ctx: Any) -> None:
+        reports.append(event)
+        if len(reports) == 2:
+            received.set()
+
+    try:
+        kit.register_channel(SimpleChannel("sms"))
+        await kit.create_room(room_id="room-1")
+        await kit.attach_channel("room-1", "sms")
+        for name in ("one", "two"):
+            left, right = socket.socketpair()
+            ar, aw = await asyncio.open_connection(sock=left)
+            cr, cw = await asyncio.open_connection(sock=right)
+            writers.append(aw)
+            envelope = deepcopy(_envelope(f"{name}-session"))
+            envelope["agent_id"] = name
+            servers.append(asyncio.create_task(acp.run_agent(_UsageAgent(envelope), aw, ar)))
+            kit.register_channel(
+                ACPChannel(
+                    name,
+                    cwd=tmp_path,
+                    transport=(_UsageSocketPairTransport if trusted else _SocketPairTransport)(
+                        cr, cw
+                    ),
+                )
+            )
+            await kit.attach_channel("room-1", name)
+        result = await kit.process_inbound(
+            InboundMessage(channel_id="sms", sender_id="user", content=TextContent(body="go"))
+        )
+        assert result.error is None
+        await asyncio.wait_for(received.wait(), 2)
+        assert {event.usage_metadata["session_id"] for event in reports} == {
+            "one-session",
+            "two-session",
+        }
+        for event in reports:
+            assert event.room_id == "room-1"
+            assert event.usage_metadata["transport"] == "socketpair"
+            assert event.usage["input_tokens"] == 2
+            if trusted:
+                assert event.usage_metadata["agent_id"] == event.channel_id
+                assert event.usage_metadata["usage_report"]["report_id"] == "report-1"
+                assert event.usage["cost"] == 0
+            else:
+                assert "agent_id" not in event.usage_metadata
+                assert "node_id" not in event.usage_metadata
+                assert event.usage_metadata["usage_report"]["identity_source"] == "roomkit"
+                assert "cost" not in event.usage
+    finally:
+        await kit.close()
+        for task in servers:
+            task.cancel()
+        await asyncio.gather(*servers, return_exceptions=True)
+        for writer in writers:
+            writer.close()


### PR DESCRIPTION
ACP response hooks lose the native session and source of usage reports, so a host cannot distinguish a session cumulative cost from prompt counters or identify a recovered report.

Add optional `AIResponseEvent.usage_metadata` while preserving the existing `usage` map and trigger policy. Snapshot native notifications with explicit session scope and local receipt provenance; accept durable transport envelopes only after an explicit transport opt-in through `_meta["roomkit.live/usage"]`. Terminal snapshots replace live state, including absent reports, and are sealed against later notifications and preserve original result/report/session identities across replay. Model snapshots and stop reasons remain explicit. The ACP example displays a session total instead of inferring a turn price.

Validation: `make all` passed (8,835 passed, 136 skipped, 8 deselected); real SDK JSON-RPC round trip through two transports in one room to a registered framework hook; regression tests for absence/zero, model changes, late reports, session reset, replay and interruption. Companion guide and RFC updates document the contract.

Independent review fixes seal terminal observations, require transport admission for identity metadata, and share context normalization. Available adapter handshake information is also preserved.

Companion PRs: [guide](https://github.com/roomkit-live/roomkit-docs/pull/1), [RFC](https://github.com/roomkit-live/roomkit-specs/pull/1).
