### PR TITLE
fix(delivery): cancel and drain owned turn work (RMK-172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Cancelling an awaited `process_inbound()` now cancels and drains its own
+  delivery cascade, including running tools and streams, before returning.
+  Shared rooms and providers remain usable, and the next turn can resume
+  after cleanup. Deferred callers can use `await result.delivery.cancel()`;
+  `cancellation_reason` records the terminal outcome. Cleanup timeouts report
+  incomplete drainage instead of allowing premature resource disposal (RMK-172).
+
 ## [0.70.0] — 2026-09-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.71.0] — 2026-09-11
+
 ### Fixed
 
 - Cancelling an awaited `process_inbound()` now cancels and drains its own

--- a/docs/c7/rooms-and-channels.md
+++ b/docs/c7/rooms-and-channels.md
@@ -355,3 +355,23 @@ A participant is one shared record per `(room_id, participant_id)`, even when
 record, not per-channel presence. When two channel memberships have independent
 connect/disconnect lifecycles, give them distinct participant ids and correlate
 them through `identity_id`.
+
+## Cancelling a turn
+
+Cancelling a task awaiting `kit.process_inbound()` cancels and drains that
+call's tools, generation and stream consumers before propagating
+`asyncio.CancelledError`. Other rooms and shared providers remain usable.
+Committed events and already streamed text remain in the timeline.
+
+With `defer_delivery=True`, explicitly call
+`await result.delivery.cancel(reason="hangup", timeout=5.0)` to stop that turn.
+The returned result's `cancellation_reason` names its terminal cancellation;
+`await result.delivery.wait()` joins the same cleanup. Cancelling a `wait()`
+alone leaves deferred work running. A completed handle is unchanged by cancel.
+
+The default cleanup budget is five seconds on both paths. `TimeoutError`
+means cleanup is incomplete: keep resources still in use, and for a deferred
+call await its handle later. Repeated cancellation does not interrupt
+finalizers. A handle cannot drain its own room lock or lane (`RuntimeError`).
+External effects already committed and tasks detached by application handlers
+are outside this cancellation contract. See `examples/cancel_delivery.py`.

--- a/examples/cancel_delivery.py
+++ b/examples/cancel_delivery.py
@@ -1,0 +1,70 @@
+"""Cancel a suspended tool, drain it, and continue using the same RoomKit.
+
+Run with: uv run python examples/cancel_delivery.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from roomkit import Agent, ChannelCategory, InboundMessage, RoomKit, TextContent, WebSocketChannel
+from roomkit.providers.ai.base import AIResponse, AITool, AIToolCall
+from roomkit.providers.ai.mock import MockAIProvider
+
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    started, finished = asyncio.Event(), asyncio.Event()
+
+    async def lookup(name: str, arguments: dict[str, Any]) -> str:
+        started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            finished.set()
+        return "unreachable"
+
+    provider = MockAIProvider(
+        ai_responses=[
+            AIResponse(
+                content="", tool_calls=[AIToolCall(id="call", name="lookup", arguments={})]
+            ),
+            AIResponse(content="Ready for the next turn"),
+        ]
+    )
+    kit = RoomKit()
+    kit.register_channel(WebSocketChannel("input"))
+    kit.register_channel(
+        Agent(
+            "agent",
+            provider=provider,
+            tool_handler=lookup,
+            tools=[
+                AITool(name="lookup", description="Example lookup", parameters={"type": "object"}),
+            ],
+        )
+    )
+    await kit.create_room(room_id="example")
+    await kit.attach_channel("example", "input")
+    await kit.attach_channel("example", "agent", category=ChannelCategory.INTELLIGENCE)
+    message = InboundMessage(channel_id="input", sender_id="user", content=TextContent(body="Go"))
+    try:
+        result = await kit.process_inbound(message, room_id="example", defer_delivery=True)
+        await started.wait()
+        if result.delivery is not None:
+            await result.delivery.cancel(reason="hangup")
+            logger.info(
+                "Cancelled: %s; tool finished: %s", result.cancellation_reason, finished.is_set()
+            )
+        next_turn = await kit.process_inbound(message, room_id="example")
+        logger.info("Next turn: %s", next_turn.response_events[-1].content)
+    finally:
+        await kit.close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -861,6 +861,26 @@ A participant is one shared record per `(room_id, participant_id)`, even when
 record, not per-channel presence. When two channel memberships have independent
 connect/disconnect lifecycles, give them distinct participant ids and correlate
 them through `identity_id`.
+
+## Cancelling a turn
+
+Cancelling a task awaiting `kit.process_inbound()` cancels and drains that
+call's tools, generation and stream consumers before propagating
+`asyncio.CancelledError`. Other rooms and shared providers remain usable.
+Committed events and already streamed text remain in the timeline.
+
+With `defer_delivery=True`, explicitly call
+`await result.delivery.cancel(reason="hangup", timeout=5.0)` to stop that turn.
+The returned result's `cancellation_reason` names its terminal cancellation;
+`await result.delivery.wait()` joins the same cleanup. Cancelling a `wait()`
+alone leaves deferred work running. A completed handle is unchanged by cancel.
+
+The default cleanup budget is five seconds on both paths. `TimeoutError`
+means cleanup is incomplete: keep resources still in use, and for a deferred
+call await its handle later. Repeated cancellation does not interrupt
+finalizers. A handle cannot drain its own room lock or lane (`RuntimeError`).
+External effects already committed and tasks detached by application handlers
+are outside this cancellation contract. See `examples/cancel_delivery.py`.
 ---
 
 Hooks intercept events at specific points in the processing pipeline. They can block messages, modify content, trigger side effects, or observe the conversation.

--- a/src/roomkit/channels/_ai_resilience.py
+++ b/src/roomkit/channels/_ai_resilience.py
@@ -20,9 +20,11 @@ from roomkit.providers.ai.base import (
     StreamToolCallDelta,
     is_context_overflow_message,
 )
+from roomkit.providers.utils import _aclose_stream
 
 if TYPE_CHECKING:
     from roomkit.channels._tool_eviction import ToolEviction
+
 
 logger = logging.getLogger("roomkit.channels.ai")
 
@@ -156,8 +158,9 @@ class AIResilienceMixin:
         while attempt <= policy.max_retries:
             emitted = False
             projected_composition = False
+            stream = self._provider.generate_structured_stream(context)
             try:
-                async for event in self._provider.generate_structured_stream(context):
+                async for event in stream:
                     # A composition delta is a projection: it is neither
                     # delivered as text nor persisted, so a stream that has
                     # only produced those can still be replayed without
@@ -207,13 +210,16 @@ class AIResilienceMixin:
                 if projected_composition:
                     yield _StreamRetryBoundary()
                 raise
+            finally:
+                await _aclose_stream(stream)
 
         # Fallback — only reachable when nothing was emitted.
         if self._fallback_provider and last_error:
             logger.warning("Trying fallback provider for stream.")
             projected_composition = False
+            stream = self._fallback_provider.generate_structured_stream(context)
             try:
-                async for event in self._fallback_provider.generate_structured_stream(context):
+                async for event in stream:
                     if isinstance(event, StreamToolCallDelta):
                         projected_composition = True
                     yield event
@@ -221,6 +227,8 @@ class AIResilienceMixin:
                 if projected_composition:
                     yield _StreamRetryBoundary()
                 raise
+            finally:
+                await _aclose_stream(stream)
             return
 
         if last_error:

--- a/src/roomkit/channels/_ai_streaming.py
+++ b/src/roomkit/channels/_ai_streaming.py
@@ -37,6 +37,7 @@ from roomkit.providers.ai.base import (
     StreamToolCall,
     StreamToolCallDelta,
 )
+from roomkit.providers.utils import _aclose_stream
 from roomkit.realtime.base import EphemeralEventType
 from roomkit.telemetry.base import Attr, SpanKind
 from roomkit.telemetry.context import get_current_span
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
     from roomkit.models.context import RoomContext
     from roomkit.providers.ai.base import StreamEvent
     from roomkit.telemetry.noop import NoopTelemetryProvider
+
 
 logger = logging.getLogger("roomkit.channels.ai")
 
@@ -283,9 +285,11 @@ class AIStreamingMixin(AIToolLoopRulesMixin):
         thinking_published = 0
         thinking_started = False
         coalescer = self._new_thinking_coalescer(room_id, round_idx=0)
+        stream: Any = None
         try:
             if not self._provider.supports_structured_streaming:
-                async for chunk in self._provider.generate_stream(ai_context):
+                stream = self._provider.generate_stream(ai_context)
+                async for chunk in stream:
                     text_parts.append(chunk)
                     yield chunk
                 completed = True
@@ -294,7 +298,8 @@ class AIStreamingMixin(AIToolLoopRulesMixin):
             # Through the resilience wrapper, like every structured generation:
             # retry, fallback and overflow compaction are the wrapper's to give,
             # never a per-path courtesy.
-            async for ev in self._generate_stream_with_retry(ai_context):
+            stream = self._generate_stream_with_retry(ai_context)
+            async for ev in stream:
                 if isinstance(ev, _StreamRetryBoundary):
                     continue
                 if isinstance(ev, StreamThinkingDelta):
@@ -332,6 +337,7 @@ class AIStreamingMixin(AIToolLoopRulesMixin):
             completed = True
         finally:
             try:
+                await _aclose_stream(stream)
                 # A window still open here was left by an abnormal exit — a
                 # provider error, a consumer that closed the stream — and
                 # closes with the block reasoned so far, so THINKING_START
@@ -448,6 +454,7 @@ class AIStreamingMixin(AIToolLoopRulesMixin):
         thinking_published = 0
         coalescer = self._new_thinking_coalescer(room_id, round_idx=0)
         _round_idx = 0
+        stream: Any = None
         try:
             context, should_cancel = self._drain_steering_queue(context, loop_ctx)
             if should_cancel:
@@ -490,7 +497,8 @@ class AIStreamingMixin(AIToolLoopRulesMixin):
                 _dedup_offset = 0
                 _dedup_buffer: list[str] = []
 
-                async for event in self._generate_stream_with_retry(context):
+                stream = self._generate_stream_with_retry(context)
+                async for event in stream:
                     # Check cancel between every stream event — allows immediate
                     # cancellation instead of waiting for the full stream to finish.
                     if loop_ctx.cancel_event.is_set():
@@ -922,6 +930,7 @@ class AIStreamingMixin(AIToolLoopRulesMixin):
             raise
         finally:
             try:
+                await _aclose_stream(stream)
                 # A window still open here was left by an abnormal exit — a
                 # provider error, a consumer that closed the stream — and
                 # closes with the block reasoned so far, the way a cancelled

--- a/src/roomkit/core/event_router.py
+++ b/src/roomkit/core/event_router.py
@@ -40,6 +40,7 @@ from roomkit.models.event import (
 )
 from roomkit.models.task import Observation, Task
 from roomkit.providers.ai.base import ProviderError
+from roomkit.providers.utils import _aclose_stream
 
 logger = logging.getLogger("roomkit.event_router")
 
@@ -57,19 +58,6 @@ def _log_target_failure(what: str, channel_id: str, exc: Exception, extra: dict[
         logger.warning("%s %s failed: %s", what, channel_id, exc, extra=extra)
     else:
         logger.exception("%s %s failed", what, channel_id, extra=extra)
-
-
-async def _aclose_stream(stream: Any) -> None:
-    """Close an un-consumed response stream without generating its reply.
-
-    A muted channel's streamed voice is dropped: the async generator is never
-    iterated, so no provider round-trip runs. Closing it releases the object
-    cleanly (and silences the ``async generator was never awaited`` warning).
-    A stream without ``aclose`` is left to be garbage-collected.
-    """
-    aclose = getattr(stream, "aclose", None)
-    if aclose is not None:
-        await aclose()
 
 
 def _solicits(

--- a/src/roomkit/core/lanes.py
+++ b/src/roomkit/core/lanes.py
@@ -30,7 +30,9 @@ import asyncio
 import contextlib
 import contextvars
 import logging
+import math
 from collections import deque
+from collections.abc import Coroutine
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -141,6 +143,8 @@ class DeliveryCascade:
         "response_events",
         "room_id",
         "streams",
+        "_tasks",
+        "_cleanup_task",
     )
 
     def __init__(self, room_id: str, *, reentry_budget: int) -> None:
@@ -167,6 +171,83 @@ class DeliveryCascade:
         # whose deliveries belong to its own result, and merging them here
         # would collide on any channel both passes reached.
         self.delivery_results: dict[str, Any] = {}
+        self._tasks: set[asyncio.Task[Any]] = set()
+        self._cleanup_task: asyncio.Task[None] | None = None
+
+    @property
+    def drained(self) -> bool:
+        """No owned execution or stream consumer is still unwinding."""
+        return all(task.done() for task in self._tasks) and (
+            self._cleanup_task is None or self._cleanup_task.done()
+        )
+
+    def track(self, task: asyncio.Task[Any]) -> None:
+        """Own a task before it can start; cancellation is sent only once."""
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        if self.cancelled is not None:
+            task.cancel()
+
+    async def run[T](self, work: Coroutine[Any, Any, T]) -> T:
+        """Execute owned work without giving its waiter cancellation ownership."""
+        if self.cancelled is not None:
+            work.close()
+            raise asyncio.CancelledError
+        task = asyncio.create_task(work)
+        self.track(task)
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            # The lane itself can also be stopped by framework shutdown.
+            # Leave its child no more cancellation-resistant than before.
+            if not task.done() and not task.cancelling():
+                task.cancel()
+            raise
+
+    async def wait_drained(self) -> None:
+        """Join running work, including its asynchronous finalizers."""
+        while pending := {task for task in self._tasks if not task.done()}:
+            await asyncio.wait(pending)
+        if self._cleanup_task is not None:
+            await asyncio.shield(self._cleanup_task)
+
+    async def _cleanup(self) -> None:
+        while pending := {task for task in self._tasks if not task.done()}:
+            await asyncio.wait(pending)
+        # Also close streams whose consumer was cancelled before its first
+        # step. No generator is closed concurrently with its running task.
+        for response in self.streams:
+            close = getattr(response.stream, "aclose", None)
+            if close is not None:
+                await close()
+
+    async def cancel_and_wait(self, reason: str, timeout: float = 5.0) -> None:
+        """Request cancellation once and join cleanup within one fixed budget.
+
+        Repeated cancellation of the waiting task never interrupts the owned
+        finalizers. An expiry reports incomplete cleanup; it does not release
+        resources or claim that the turn is safe to dispose.
+        """
+        if not math.isfinite(timeout) or timeout < 0:
+            raise ValueError("timeout must be finite and non-negative")
+        if self.waiter_would_deadlock():
+            raise RuntimeError("Cannot drain delivery from its lane or room lock")
+        self.cancel(reason)
+        deadline = asyncio.get_running_loop().time() + timeout
+        interrupted = False
+        assert self._cleanup_task is not None
+        while not self._cleanup_task.done():
+            remaining = max(0.0, deadline - asyncio.get_running_loop().time())
+            try:
+                _, pending = await asyncio.wait({self._cleanup_task}, timeout=remaining)
+            except asyncio.CancelledError:
+                interrupted = True
+                continue
+            if pending:
+                raise TimeoutError(f"Delivery cleanup incomplete for room {self.room_id}")
+        self._cleanup_task.result()
+        if interrupted:
+            raise asyncio.CancelledError
 
     def retain(self) -> None:
         """Account one pending unit. Call before any await can fail."""
@@ -196,8 +277,18 @@ class DeliveryCascade:
 
     def cancel(self, reason: str) -> None:
         """Abort the cascade: wake every waiter, keep the reason."""
+        if self.cancelled is not None:
+            return
         self.cancelled = reason
+        for task in self._tasks:
+            if not task.done() and not task.cancelling():
+                task.cancel()
         self._done.set()
+        self._cleanup_task = asyncio.create_task(
+            self._cleanup(),
+            context=contextvars.Context(),
+            name=f"roomkit-delivery-cleanup-{self.room_id}",
+        )
 
     async def wait(self) -> bool:
         """Wait for the cascade to complete.
@@ -621,7 +712,13 @@ class RoomDeliveryLane:
         """
         run = _Executed(entry)
         executed.append(run)
-        run.result = await self._execute(entry)
+        try:
+            run.result = await entry.cascade.run(self._execute(entry))
+        except asyncio.CancelledError:
+            if entry.cascade.cancelled is None:
+                raise
+            # Still consume the committed index; cancellation must not leave
+            # a cursor hole or stop another cascade in the same lane.
 
     async def _execute(self, entry: ExecEntry) -> Any:
         """Run one plan's delivery set; a failure is recorded, never raised.
@@ -652,16 +749,12 @@ class RoomDeliveryLane:
         parent — would be trace roots instead of children of the inbound or
         send_event span that started the turn.
         """
-        plan = entry.plan
         try:
-            if result is not None:
-                with restored_span(plan.parent_span_id, telemetry_ctx=plan.parent_span_ctx):
-                    await self._host._post_plan_effects(plan, result, entry.cascade)
-                    await self._host._reentry_commit_pass(
-                        self.room_id, plan, result, entry.cascade
-                    )
+            if result is not None and entry.cascade.cancelled is None:
+                await entry.cascade.run(self._finish_effects(entry, result))
         except asyncio.CancelledError:
-            raise
+            if entry.cascade.cancelled is None:
+                raise
         except Exception as exc:
             # Post-plan effects include a real write (side-effect persistence):
             # the failure must reach the caller, not just the log.
@@ -669,6 +762,13 @@ class RoomDeliveryLane:
             entry.cascade.record_error(exc)
         finally:
             entry.cascade.release()
+
+    async def _finish_effects(self, entry: ExecEntry, result: Any) -> None:
+        plan = entry.plan
+        with restored_span(plan.parent_span_id, telemetry_ctx=plan.parent_span_ctx):
+            await self._host._post_plan_effects(plan, result, entry.cascade)
+            if entry.cascade.cancelled is None:
+                await self._host._reentry_commit_pass(self.room_id, plan, result, entry.cascade)
 
 
 class RoomLaneRegistry:

--- a/src/roomkit/core/lanes.py
+++ b/src/roomkit/core/lanes.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from roomkit.core.locks import _has_room_lock, _held_rooms
 from roomkit.models.response_metadata import ResponseMetadata
+from roomkit.providers.utils import _aclose_stream
 from roomkit.telemetry.context import restored_span
 
 if TYPE_CHECKING:
@@ -198,8 +199,7 @@ class DeliveryCascade:
         try:
             return await asyncio.shield(task)
         except asyncio.CancelledError:
-            # The lane itself can also be stopped by framework shutdown.
-            # Leave its child no more cancellation-resistant than before.
+            # Framework shutdown also stops the lane's running child.
             if not task.done() and not task.cancelling():
                 task.cancel()
             raise
@@ -217,9 +217,7 @@ class DeliveryCascade:
         # Also close streams whose consumer was cancelled before its first
         # step. No generator is closed concurrently with its running task.
         for response in self.streams:
-            close = getattr(response.stream, "aclose", None)
-            if close is not None:
-                await close()
+            await _aclose_stream(response.stream)
 
     async def cancel_and_wait(self, reason: str, timeout: float = 5.0) -> None:
         """Request cancellation once and join cleanup within one fixed budget.

--- a/src/roomkit/core/mixins/inbound.py
+++ b/src/roomkit/core/mixins/inbound.py
@@ -21,6 +21,7 @@ from roomkit.models.enums import (
 if TYPE_CHECKING:
     from roomkit.channels.base import Channel
     from roomkit.core.inbound_router import InboundRoomRouter
+    from roomkit.core.lanes import DeliveryCascade
     from roomkit.core.locks import RoomLockManager
     from roomkit.identity.base import IdentityResolver
     from roomkit.models.context import RoomContext
@@ -122,6 +123,14 @@ class InboundMixin(HelpersMixin):
                 event while the agent's turn runs on (an HTTP route returning
                 200, say); ``delivery_results`` is backfilled by
                 ``delivery.wait()``.
+
+        Cancelling an awaited call cancels only its delivery cascade and
+        drains owned generation, tools and streams before propagating
+        ``CancelledError``. Cleanup has a five-second budget; ``TimeoutError``
+        reports that work is still unwinding and its resources must be kept.
+        Deferred callers explicitly use ``result.delivery.cancel()``;
+        cancelling a handle's ``wait()`` cancels only that wait. Committed
+        timeline events are retained in either case.
         """
         from roomkit.telemetry.base import SpanKind
         from roomkit.telemetry.context import get_current_span, reset_span, set_current_span
@@ -343,13 +352,49 @@ class InboundMixin(HelpersMixin):
         (§13.6): a room whose lock is held by a stuck event would otherwise
         queue every later message with nothing to stop it, which is the pile-up
         the setting exists for. Past the lock, ``_process_locked`` spends what
-        remains on the pre-commit gates and stops there — the commit and the
-        delivery set it hands to the lane are not cancellable, or a committed
-        event would come back reported as blocked.
+        remains on the pre-commit gates and stops there. That timeout never
+        invalidates a committed event. Explicit caller cancellation instead
+        stops the delivery tail, retaining the committed timeline record.
         """
         from roomkit.core.lanes import DeliveryCascade
 
         cascade = DeliveryCascade(room_id, reentry_budget=self._max_chain_depth * 10)
+        try:
+            return await self._complete_inbound_delivery(
+                event,
+                context,
+                resolved_identity,
+                pending_id_result,
+                message,
+                channel,
+                room_id,
+                deadline,
+                cascade,
+                defer_delivery=defer_delivery,
+            )
+        except BaseException:
+            # The caller owns this cascade even if setup failed after commit,
+            # before it could receive a deferred handle. Drain off the lock.
+            if cascade.waiter_would_deadlock():
+                cascade.cancel("caller_cancelled")
+            else:
+                await cascade.cancel_and_wait("caller_cancelled")
+            raise
+
+    async def _complete_inbound_delivery(
+        self,
+        event: Any,
+        context: RoomContext,
+        resolved_identity: Identity | None,
+        pending_id_result: IdentityResult | None,
+        message: InboundMessage,
+        channel: Channel,
+        room_id: str,
+        deadline: float,
+        cascade: DeliveryCascade,
+        *,
+        defer_delivery: bool,
+    ) -> InboundResult:
         async with AsyncExitStack() as stack:
             try:
                 async with asyncio.timeout_at(deadline):
@@ -391,6 +436,9 @@ class InboundMixin(HelpersMixin):
         # mutation and ON_ERROR hooks fire from the lane executor, off this
         # room's lock.
         completed = await cascade.wait()
+        if cascade.cancelled is not None:
+            await cascade.wait_drained()
+        result.cancellation_reason = cascade.cancelled
         if cascade.error is not None and result.error is None:
             result.error = cascade.error
         # Step 18 reports the delivery set the caller waited for.
@@ -408,9 +456,14 @@ class InboundMixin(HelpersMixin):
         # reply is only generated when its stream is consumed.
         if not completed:
             self._consume_streams_when_cascade_completes(cascade, room_id)
-        elif cascade.streams:
-            stream_error, record = await self._process_streaming_responses(
-                cascade.streams, room_id, response_events=result.response_events
+        elif cascade.streams and cascade.cancelled is None:
+            stream_error, record = await cascade.run(
+                self._process_streaming_responses(
+                    cascade.streams,
+                    room_id,
+                    response_events=result.response_events,
+                    cascade=cascade,
+                )
             )
             if stream_error is not None and result.error is None:
                 result.error = stream_error

--- a/src/roomkit/core/mixins/inbound_streaming.py
+++ b/src/roomkit/core/mixins/inbound_streaming.py
@@ -98,6 +98,7 @@ class InboundStreamingMixin(HelpersMixin):
         context: RoomContext,
         *,
         response_events: list[RoomEvent] | None = None,
+        cascade: DeliveryCascade | None = None,
     ) -> _StreamingResult | None:
         """Consume a streaming response, pipe to streaming channels, store segments."""
         from roomkit.models.event import EventSource, TextContent
@@ -118,7 +119,8 @@ class InboundStreamingMixin(HelpersMixin):
         # enqueued without waiting (blocking the generator on an SMS round
         # trip would stall the stream), and the run is awaited once, after
         # the stream, by the caller.
-        cascade = DeliveryCascade(room_id, reentry_budget=self._max_chain_depth * 10)
+        if cascade is None:
+            cascade = DeliveryCascade(room_id, reentry_budget=self._max_chain_depth * 10)
         # The channel a text segment is reaching *as it is produced* — the
         # stream itself is its delivery, so the lane must not send it again.
         # Only the first target streams (V1, below); any other streaming-capable
@@ -475,6 +477,7 @@ class InboundStreamingMixin(HelpersMixin):
         room_id: str,
         *,
         response_events: list[RoomEvent] | None = None,
+        cascade: DeliveryCascade | None = None,
     ) -> tuple[Exception | None, ResponseMetadata]:
         """Handle streaming responses outside the room lock.
 
@@ -503,15 +506,24 @@ class InboundStreamingMixin(HelpersMixin):
 
         first_error: Exception | None = None
         record = ResponseMetadata()
-        for sr in pending_streams:
-            sr_result = await self._handle_streaming_response(
-                router, sr, room_id, context, response_events=response_events
-            )
-            if sr_result and sr_result.error and first_error is None:
-                first_error = sr_result.error
-            # Several streams answer one inbound only when several channels
-            # replied; each writes under its own key, so merging keeps them
-            # all rather than letting the last one win.
-            record.update(sr.response_metadata or {})
+        try:
+            for sr in pending_streams:
+                sr_result = await self._handle_streaming_response(
+                    router, sr, room_id, context, response_events=response_events, cascade=cascade
+                )
+                if sr_result and sr_result.error and first_error is None:
+                    first_error = sr_result.error
+                # Several streams answer one inbound only when several channels
+                # replied; each writes under its own key, so merging keeps them
+                # all rather than letting the last one win.
+                record.update(sr.response_metadata or {})
+        finally:
+            # A transport can stop reading between two yields (or fail while
+            # rendering one). Async-for alone does not close its generator;
+            # finalizers must run before the delivery handle reports cleanup.
+            for sr in pending_streams:
+                close = getattr(sr.stream, "aclose", None)
+                if close is not None:
+                    await close()
 
         return first_error, record

--- a/src/roomkit/core/mixins/inbound_streaming.py
+++ b/src/roomkit/core/mixins/inbound_streaming.py
@@ -24,6 +24,7 @@ from roomkit.models.event import RoomEvent, ToolCallContent
 from roomkit.models.response_metadata import ResponseMetadata
 from roomkit.models.streaming import ThinkingDeltaMarker, ToolCallEndMarker, ToolCallStartMarker
 from roomkit.providers.ai.base import ProviderError
+from roomkit.providers.utils import _aclose_stream
 
 if TYPE_CHECKING:
     from roomkit.channels.base import Channel
@@ -522,8 +523,6 @@ class InboundStreamingMixin(HelpersMixin):
             # rendering one). Async-for alone does not close its generator;
             # finalizers must run before the delivery handle reports cleanup.
             for sr in pending_streams:
-                close = getattr(sr.stream, "aclose", None)
-                if close is not None:
-                    await close()
+                await _aclose_stream(sr.stream)
 
         return first_error, record

--- a/src/roomkit/core/mixins/lane_execution.py
+++ b/src/roomkit/core/mixins/lane_execution.py
@@ -410,7 +410,10 @@ class LaneExecutionMixin(HelpersMixin):
                 # to its caller — record it so a DeliveryHandle surfaces it.
                 try:
                     stream_error, record = await self._process_streaming_responses(
-                        cascade.streams, room_id, response_events=cascade.response_events
+                        cascade.streams,
+                        room_id,
+                        response_events=cascade.response_events,
+                        cascade=cascade,
                     )
                 except Exception as exc:
                     logger.exception("Detached stream consumption failed for room %s", room_id)
@@ -453,6 +456,7 @@ class LaneExecutionMixin(HelpersMixin):
             name=f"roomkit-detached-streams-{room_id}",
             context=contextvars.Context(),
         )
+        cascade.track(task)
         task.add_done_callback(_end_tail)
         task.add_done_callback(self._pending_hook_tasks.discard)
         self._pending_hook_tasks.add(task)

--- a/src/roomkit/models/delivery.py
+++ b/src/roomkit/models/delivery.py
@@ -171,7 +171,7 @@ class DeliveryHandle:
         the same short-circuit the waiting path's step 18 applies, with
         delivery following in lane order.
         """
-        if not self._consumer.done() and self._cascade.waiter_would_deadlock():
+        if not self.done and self._cascade.waiter_would_deadlock():
             return self._result
         await asyncio.wait({self._consumer})
         if self._cascade.cancelled is not None:

--- a/src/roomkit/models/delivery.py
+++ b/src/roomkit/models/delivery.py
@@ -25,6 +25,14 @@ if TYPE_CHECKING:
         error: Exception | None
         response_metadata: ResponseMetadata
         response_events: list[RoomEvent]
+        cancelled: str | None
+
+        @property
+        def drained(self) -> bool: ...
+
+        async def cancel_and_wait(self, reason: str, timeout: float = 5.0) -> None: ...
+
+        async def wait_drained(self) -> None: ...
 
         def waiter_would_deadlock(self) -> bool: ...
 
@@ -126,14 +134,33 @@ class DeliveryHandle:
         "nothing more will happen", not "everything ran". ``wait()``'s
         backfill is where the two read differently.
         """
-        return self._consumer.done()
+        return self._consumer.done() and self._cascade.drained
+
+    async def cancel(
+        self, *, reason: str = "caller_cancelled", timeout: float = 5.0
+    ) -> InboundResult:
+        """Cancel this turn and drain its tools, generation and streams.
+
+        Returns the original result with ``cancellation_reason`` set. Already
+        committed events remain stored. Other turns and shared providers are
+        unaffected. Repeated calls are safe and preserve the first reason.
+
+        ``TimeoutError`` means cleanup is STILL running: retain the resources
+        it uses and await this handle before disposing them. Cancellation of
+        this call is propagated only after cleanup (or its timeout). Calling
+        from the room's lane or under its lock raises ``RuntimeError``.
+        A completed handle is returned unchanged.
+        """
+        if not self.done:
+            await self._cascade.cancel_and_wait(reason, timeout)
+        return await self.wait()
 
     async def wait(self) -> InboundResult:
         """Wait for the deferred delivery to complete, then report it.
 
         Backfills ``delivery_results``, ``error`` and ``response_metadata`` on
         the result this handle belongs to — after this the result reads exactly
-        like a non-deferred call's — and returns that result. Never raises: a
+        like a non-deferred call's — and returns that result. A
         consumer cancelled by ``close()`` resolves the wait too, with whatever
         the cascade recorded by then.
 
@@ -147,11 +174,14 @@ class DeliveryHandle:
         if not self._consumer.done() and self._cascade.waiter_would_deadlock():
             return self._result
         await asyncio.wait({self._consumer})
+        if self._cascade.cancelled is not None:
+            await self._cascade.wait_drained()
         self._result.delivery_results = self._cascade.delivery_results
         self._result.response_metadata.update(self._cascade.response_metadata)
         self._result.response_events = list(self._cascade.response_events)
         if self._result.error is None:
             self._result.error = self._cascade.error
+        self._result.cancellation_reason = self._cascade.cancelled
         return self._result
 
 
@@ -177,6 +207,12 @@ class InboundResult(BaseModel):
     blocked: bool = False
     reason: str | None = None
     error: Exception | None = None
+    cancellation_reason: str | None = None
+    """Terminal delivery cancellation reason; never changes the committed event.
+
+    Backfilled by a deferred handle's ``wait()`` or ``cancel()`` after cleanup.
+    An awaited ``process_inbound`` propagates ``CancelledError`` after draining.
+    """
     response_metadata: ResponseMetadata = Field(default_factory=ResponseMetadata)
     """The turn's response-metadata record; empty when no turn ran."""
 

--- a/src/roomkit/providers/utils.py
+++ b/src/roomkit/providers/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 import binascii
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     import httpx
@@ -17,6 +17,13 @@ class HTTPTimeouts(Protocol):
 
     timeout: float
     connect_timeout: float
+
+
+async def _aclose_stream(stream: Any) -> None:
+    """Join an iterator's finalizer when its contract supports explicit close."""
+    close = getattr(stream, "aclose", None)
+    if close is not None:
+        await close()
 
 
 def extract_event_text(event: RoomEvent) -> str:

--- a/tests/test_delivery_cancellation.py
+++ b/tests/test_delivery_cancellation.py
@@ -289,6 +289,10 @@ async def test_cancel_timeout_reports_incomplete_cleanup_and_can_be_joined() -> 
         assert not handle.done
         assert not tool.finished.is_set()
         assert ai.active_turns == 1
+        async with kit._lock_manager.locked("owned"):
+            async with asyncio.timeout(0.1):
+                assert await handle.wait() is result
+            assert not handle.done
         tool.cleanup.set()
         await asyncio.wait_for(handle.wait(), 2)
         assert handle.done

--- a/tests/test_delivery_cancellation.py
+++ b/tests/test_delivery_cancellation.py
@@ -1,0 +1,363 @@
+"""A turn owns its work until cancellation cleanup has finished."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from roomkit import Agent, ChannelCategory, InboundMessage, RoomKit, TextContent
+from roomkit.providers.ai.base import AIResponse, AITool, AIToolCall
+from roomkit.providers.ai.mock import MockAIProvider
+from tests.test_framework import SimpleChannel
+
+
+class PausedTool:
+    def __init__(self, *, slow_cleanup: bool = False, suppress: bool = False) -> None:
+        self.started = asyncio.Event()
+        self.unwinding = asyncio.Event()
+        self.finished = asyncio.Event()
+        self.release = asyncio.Event()
+        self.cleanup = asyncio.Event()
+        if not slow_cleanup:
+            self.cleanup.set()
+        self.suppress = suppress
+        self.calls: list[str] = []
+        self.effects: list[str] = []
+
+    async def __call__(self, name: str, arguments: dict[str, Any]) -> str:
+        self.calls.append(name)
+        self.started.set()
+        try:
+            await self.release.wait()
+            self.effects.append(name)
+        except asyncio.CancelledError:
+            if not self.suppress:
+                raise
+        finally:
+            self.unwinding.set()
+            await self.cleanup.wait()
+            self.finished.set()
+        return "result"
+
+
+def message(text: str = "Work") -> InboundMessage:
+    return InboundMessage(channel_id="input", sender_id="user", content=TextContent(body=text))
+
+
+async def setup(
+    tool: PausedTool, *, streaming: bool = False
+) -> tuple[RoomKit, Agent, MockAIProvider]:
+    provider = MockAIProvider(
+        streaming=streaming,
+        ai_responses=[
+            AIResponse(
+                content="",
+                tool_calls=[
+                    AIToolCall(id="first", name="first", arguments={}),
+                ],
+            ),
+            AIResponse(content="Resumed"),
+        ],
+    )
+    provider.close = AsyncMock()
+    ai = Agent(
+        "ai",
+        provider=provider,
+        tool_handler=tool,
+        tools=[
+            AITool(name=name, description=name, parameters={"type": "object", "properties": {}})
+            for name in ("first", "second")
+        ],
+    )
+    kit = RoomKit()
+    kit.register_channel(SimpleChannel("input"))
+    kit.register_channel(ai)
+    for room_id in ("owned", "other"):
+        await kit.create_room(room_id=room_id)
+        await kit.attach_channel(room_id, "input")
+    await kit.attach_channel("owned", "ai", category=ChannelCategory.INTELLIGENCE)
+    other = Agent("other-ai", provider=MockAIProvider(responses=["Other room works"]))
+    kit.register_channel(other)
+    await kit.attach_channel("other", "other-ai", category=ChannelCategory.INTELLIGENCE)
+    return kit, ai, provider
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_caller_cancellation_drains_tool_and_preserves_other_room(streaming: bool) -> None:
+    tool = PausedTool()
+    kit, ai, provider = await setup(tool, streaming=streaming)
+    try:
+        caller = asyncio.create_task(kit.process_inbound(message(), room_id="owned"))
+        await asyncio.wait_for(tool.started.wait(), 2)
+        caller.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(caller, 2)
+        assert tool.finished.is_set()
+        assert tool.calls == ["first"]
+        assert tool.effects == []
+        assert len(provider.calls) == 1
+        assert ai.active_turns == 0
+        provider.close.assert_not_awaited()
+        other = await kit.process_inbound(message(), room_id="other")
+        assert other.response_events[0].content.body == "Other room works"
+        resumed = await kit.process_inbound(message("Continue"), room_id="owned")
+        assert resumed.response_events[-1].content.body == "Resumed"
+        assert tool.calls == ["first"]
+    finally:
+        tool.release.set()
+        tool.cleanup.set()
+        await kit.close()
+
+
+async def test_queued_turn_in_same_room_survives_cancelled_cascade() -> None:
+    tool = PausedTool(slow_cleanup=True)
+    kit, ai, provider = await setup(tool)
+    try:
+        first = await kit.process_inbound(message(), room_id="owned", defer_delivery=True)
+        await tool.started.wait()
+        second = await kit.process_inbound(
+            message("Independent"), room_id="owned", defer_delivery=True
+        )
+        assert first.delivery is not None and second.delivery is not None
+        cancelled = asyncio.create_task(first.delivery.cancel())
+        await tool.unwinding.wait()
+        assert not second.delivery.done
+        tool.cleanup.set()
+        await cancelled
+        await asyncio.wait_for(second.delivery.wait(), 2)
+        assert second.cancellation_reason is None
+        assert second.response_events[-1].content.body == "Resumed"
+        assert first.response_events == []
+        assert ai.active_turns == 0
+        assert len(provider.calls) == 2
+    finally:
+        tool.cleanup.set()
+        await kit.close()
+
+
+async def test_queued_cancel_does_not_wait_for_unrelated_tool() -> None:
+    tool = PausedTool()
+    kit, _, _ = await setup(tool)
+    try:
+        first = await kit.process_inbound(message(), room_id="owned", defer_delivery=True)
+        await tool.started.wait()
+        second = await kit.process_inbound(
+            message("Never execute"), room_id="owned", defer_delivery=True
+        )
+        assert first.delivery is not None and second.delivery is not None
+        await second.delivery.cancel(timeout=0.1)
+        assert not tool.unwinding.is_set()
+        assert not first.delivery.done
+        assert second.delivery.done
+        tool.release.set()
+        await asyncio.wait_for(first.delivery.wait(), 2)
+        third = await kit.process_inbound(message("Next"), room_id="owned")
+        assert third.error is None
+        assert second.response_events == []
+    finally:
+        tool.release.set()
+        await kit.close()
+
+
+@pytest.mark.parametrize("failure", ["cancel", "error"])
+@pytest.mark.parametrize("deferred", [False, True])
+async def test_post_commit_setup_failure_drains_owned_tool(failure: str, deferred: bool) -> None:
+    tool = PausedTool()
+    kit, ai, _ = await setup(tool)
+
+    async def connect(*args: Any) -> None:
+        await tool.started.wait()
+        if failure == "error":
+            raise RuntimeError("setup failed")
+        await asyncio.Future()
+
+    source = kit.get_channel("input")
+    assert source is not None
+    source.connect_session = connect
+    try:
+        # On the awaited path setup follows generation; cancellation during
+        # generation still must drain it. Deferred setup overlaps the tool.
+        caller = asyncio.create_task(
+            kit.process_inbound(
+                message().model_copy(update={"session": object()}),
+                room_id="owned",
+                defer_delivery=deferred,
+            )
+        )
+        await tool.started.wait()
+        if failure == "cancel":
+            caller.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(caller, 2)
+        else:
+            if not deferred:
+                tool.release.set()
+            with pytest.raises(RuntimeError, match="setup failed"):
+                await asyncio.wait_for(caller, 2)
+        assert tool.finished.is_set()
+        assert ai.active_turns == 0
+    finally:
+        tool.release.set()
+        await kit.close()
+
+
+async def test_cancel_under_room_lock_is_rejected_without_cancelling_turn() -> None:
+    tool = PausedTool()
+    kit, _, _ = await setup(tool)
+    try:
+        result = await kit.process_inbound(message(), room_id="owned", defer_delivery=True)
+        assert result.delivery is not None
+        await tool.started.wait()
+        async with kit._lock_manager.locked("owned"):
+            with pytest.raises(RuntimeError, match="lane or room lock"):
+                await result.delivery.cancel()
+        assert not tool.unwinding.is_set()
+        await result.delivery.cancel()
+    finally:
+        tool.release.set()
+        await kit.close()
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_deferred_cancel_is_terminal_and_releases_all_waiters(streaming: bool) -> None:
+    tool = PausedTool(slow_cleanup=True)
+    kit, ai, provider = await setup(tool, streaming=streaming)
+    try:
+        result = await kit.process_inbound(message(), room_id="owned", defer_delivery=True)
+        handle = result.delivery
+        assert handle is not None
+        await asyncio.wait_for(tool.started.wait(), 2)
+        waiters = [asyncio.create_task(handle.wait()) for _ in range(2)]
+        cancel = asyncio.create_task(handle.cancel(reason="hangup"))
+        await asyncio.wait_for(tool.unwinding.wait(), 2)
+        assert not handle.done
+        assert not cancel.done()
+        assert all(not waiter.done() for waiter in waiters)
+        tool.cleanup.set()
+        assert await asyncio.wait_for(cancel, 2) is result
+        assert all(item is result for item in await asyncio.gather(*waiters))
+        assert result.cancellation_reason == "hangup"
+        assert not result.blocked
+        assert result.error is None
+        assert handle.done
+        assert ai.active_turns == 0
+        assert tool.calls == ["first"]
+        assert await handle.cancel(reason="again") is result
+        assert result.cancellation_reason == "hangup"
+        provider.close.assert_not_awaited()
+    finally:
+        tool.release.set()
+        tool.cleanup.set()
+        await kit.close()
+
+
+async def test_second_caller_cancellation_does_not_interrupt_finalizer() -> None:
+    tool = PausedTool(slow_cleanup=True)
+    kit, ai, _ = await setup(tool)
+    try:
+        caller = asyncio.create_task(kit.process_inbound(message(), room_id="owned"))
+        await tool.started.wait()
+        caller.cancel()
+        await tool.unwinding.wait()
+        caller.cancel()
+        await asyncio.sleep(0)
+        assert not caller.done()
+        assert not tool.finished.is_set()
+        tool.cleanup.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(caller, 2)
+        assert tool.finished.is_set()
+        assert ai.active_turns == 0
+    finally:
+        tool.cleanup.set()
+        await kit.close()
+
+
+async def test_cancel_timeout_reports_incomplete_cleanup_and_can_be_joined() -> None:
+    tool = PausedTool(slow_cleanup=True)
+    kit, ai, _ = await setup(tool)
+    try:
+        result = await kit.process_inbound(message(), room_id="owned", defer_delivery=True)
+        handle = result.delivery
+        assert handle is not None
+        await tool.started.wait()
+        with pytest.raises(TimeoutError, match="cleanup incomplete"):
+            await handle.cancel(timeout=0.01)
+        assert not handle.done
+        assert not tool.finished.is_set()
+        assert ai.active_turns == 1
+        tool.cleanup.set()
+        await asyncio.wait_for(handle.wait(), 2)
+        assert handle.done
+        assert ai.active_turns == 0
+    finally:
+        tool.cleanup.set()
+        await kit.close()
+
+
+async def test_cancelling_cancel_waiter_still_finishes_cleanup() -> None:
+    tool = PausedTool(slow_cleanup=True)
+    kit, ai, _ = await setup(tool)
+    try:
+        result = await kit.process_inbound(message(), room_id="owned", defer_delivery=True)
+        handle = result.delivery
+        assert handle is not None
+        await tool.started.wait()
+        cancel = asyncio.create_task(handle.cancel())
+        await tool.unwinding.wait()
+        cancel.cancel()
+        await asyncio.sleep(0)
+        assert not cancel.done()
+        tool.cleanup.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(cancel, 2)
+        await handle.wait()
+        assert handle.done
+        assert tool.finished.is_set()
+        assert ai.active_turns == 0
+    finally:
+        tool.cleanup.set()
+        await kit.close()
+
+
+async def test_cancelled_waiter_does_not_cancel_deferred_turn() -> None:
+    tool = PausedTool()
+    kit, _, _ = await setup(tool)
+    try:
+        result = await kit.process_inbound(message(), room_id="owned", defer_delivery=True)
+        handle = result.delivery
+        assert handle is not None
+        await tool.started.wait()
+        waiter = asyncio.create_task(handle.wait())
+        await asyncio.sleep(0)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        assert not tool.unwinding.is_set()
+        assert not handle.done
+        tool.release.set()
+        await asyncio.wait_for(handle.wait(), 2)
+        assert result.cancellation_reason is None
+        assert result.response_events[-1].content.body == "Resumed"
+    finally:
+        tool.release.set()
+        await kit.close()
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_handler_suppressing_cancel_cannot_start_next_tool(streaming: bool) -> None:
+    tool = PausedTool(suppress=True)
+    kit, _, _ = await setup(tool, streaming=streaming)
+    try:
+        result = await kit.process_inbound(message(), room_id="owned", defer_delivery=True)
+        assert result.delivery is not None
+        await tool.started.wait()
+        await result.delivery.cancel(timeout=0.1)
+        assert tool.calls == ["first"]
+        assert tool.effects == []
+    finally:
+        tool.release.set()
+        await kit.close()

--- a/tests/test_delivery_cancellation_streams.py
+++ b/tests/test_delivery_cancellation_streams.py
@@ -1,0 +1,136 @@
+"""Every layer must join the provider stream's asynchronous finalizer."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from roomkit import Agent, ChannelCategory, InboundMessage, RoomKit, TextContent
+from roomkit.models.channel import ChannelBinding, ChannelOutput
+from roomkit.models.context import RoomContext
+from roomkit.models.event import RoomEvent
+from roomkit.providers.ai.base import (
+    AIContext,
+    AITool,
+    ProviderError,
+    StreamEvent,
+    StreamTextDelta,
+)
+from roomkit.providers.ai.mock import MockAIProvider
+from tests.test_framework import SimpleChannel
+
+
+class FinalizingProvider(MockAIProvider):
+    def __init__(self, *, structured: bool) -> None:
+        super().__init__(streaming=True)
+        self.structured = structured
+        self.unwinding = asyncio.Event()
+        self.release = asyncio.Event()
+        self.finished = asyncio.Event()
+
+    @property
+    def supports_structured_streaming(self) -> bool:
+        return self.structured
+
+    async def generate_stream(self, context: AIContext) -> AsyncIterator[str]:
+        try:
+            yield "partial"
+            await asyncio.Future()
+        finally:
+            self.unwinding.set()
+            await self.release.wait()
+            self.finished.set()
+
+    async def generate_structured_stream(self, context: AIContext) -> AsyncIterator[StreamEvent]:
+        try:
+            yield StreamTextDelta(text="partial")
+            await asyncio.Future()
+        finally:
+            self.unwinding.set()
+            await self.release.wait()
+            self.finished.set()
+
+
+class PausedTransport(SimpleChannel):
+    def __init__(self, *, fail: bool) -> None:
+        super().__init__("input")
+        self.fail = fail
+        self.rendering = asyncio.Event()
+
+    @property
+    def supports_streaming_delivery(self) -> bool:
+        return True
+
+    async def deliver_stream(
+        self,
+        stream: AsyncIterator[Any],
+        event: RoomEvent,
+        binding: ChannelBinding,
+        context: RoomContext,
+    ) -> ChannelOutput:
+        await anext(stream)
+        self.rendering.set()
+        if self.fail:
+            raise RuntimeError("renderer failed")
+        await asyncio.Future()
+        return ChannelOutput.empty()
+
+
+class FailingProvider(MockAIProvider):
+    async def generate_structured_stream(self, context: AIContext) -> AsyncIterator[StreamEvent]:
+        raise ProviderError("unavailable", retryable=True)
+        yield  # pragma: no cover
+
+
+@pytest.mark.parametrize("kind", ["plain", "structured", "tools", "fallback", "fallback_tools"])
+@pytest.mark.parametrize("fail", [False, True])
+async def test_stream_finalizer_finishes_before_delivery_completion(kind: str, fail: bool) -> None:
+    provider = FinalizingProvider(structured=kind != "plain")
+    transport = PausedTransport(fail=fail)
+    kwargs: dict[str, Any] = {}
+    if "tools" in kind:
+        kwargs["tools"] = [
+            AITool(name="lookup", description="lookup", parameters={"type": "object"})
+        ]
+    if kind.startswith("fallback"):
+        kwargs["fallback_provider"] = provider
+        primary = FailingProvider(streaming=True)
+    else:
+        primary = provider
+    ai = Agent("ai", provider=primary, **kwargs)
+    kit = RoomKit()
+    kit.register_channel(transport)
+    kit.register_channel(ai)
+    await kit.create_room(room_id="room")
+    await kit.attach_channel("room", "input")
+    await kit.attach_channel("room", "ai", category=ChannelCategory.INTELLIGENCE)
+    try:
+        result = await kit.process_inbound(
+            InboundMessage(channel_id="input", sender_id="user", content=TextContent(body="go")),
+            room_id="room",
+            defer_delivery=True,
+        )
+        assert result.delivery is not None
+        await asyncio.wait_for(transport.rendering.wait(), 2)
+        operation = asyncio.create_task(
+            result.delivery.wait() if fail else result.delivery.cancel()
+        )
+        await asyncio.wait_for(provider.unwinding.wait(), 2)
+        assert not operation.done()
+        assert not result.delivery.done
+        assert not provider.finished.is_set()
+        provider.release.set()
+        await asyncio.wait_for(operation, 2)
+        assert provider.finished.is_set()
+        assert ai.active_turns == 0
+        assert result.delivery.done
+        if fail:
+            assert str(result.error) == "renderer failed"
+        else:
+            assert result.cancellation_reason == "caller_cancelled"
+    finally:
+        provider.release.set()
+        await kit.close()

--- a/tests/test_inbound_stream_cancellation.py
+++ b/tests/test_inbound_stream_cancellation.py
@@ -173,3 +173,33 @@ async def test_deferred_cancellation_retains_persisted_response_events() -> None
         assert await kit.store.get_event(result.response_events[0].id) == result.response_events[0]
     finally:
         await kit.close()
+
+
+async def test_transport_failure_closes_stream_before_returning() -> None:
+    class FailingTransport(_StreamingTransport):
+        async def deliver_stream(
+            self,
+            text_stream: AsyncIterator[Any],
+            event: RoomEvent,
+            binding: ChannelBinding,
+            context: RoomContext,
+        ) -> ChannelOutput:
+            await anext(text_stream)
+            raise RuntimeError("rendering failed")
+
+    kit = RoomKit()
+    ai = AIChannel("ai", provider=_SlowStreamProvider())
+    kit.register_channel(FailingTransport("cli"))
+    kit.register_channel(ai)
+    await kit.create_room(room_id="room")
+    await kit.attach_channel("room", "cli")
+    await kit.attach_channel("room", "ai", category=ChannelCategory.INTELLIGENCE)
+    try:
+        result = await kit.process_inbound(
+            InboundMessage(channel_id="cli", sender_id="user", content=TextContent(body="go")),
+            room_id="room",
+        )
+        assert str(result.error) == "rendering failed"
+        assert ai.active_turns == 0
+    finally:
+        await kit.close()


### PR DESCRIPTION
Cancelling `process_inbound()` while a tool is suspended left its delivery lane running after the caller returned. The call now cancels and drains its own cascade before propagating cancellation, preserving other rooms and subsequent turns. Deferred callers can explicitly cancel through `DeliveryHandle.cancel()` and inspect `InboundResult.cancellation_reason`.

The existing cascade owns execution and stream consumers, including cleanup after repeated cancellation or post-commit setup failure. A timeout reports incomplete cleanup. Cancelled deliveries still advance the room cursor; committed timeline events are retained. Streaming generators are also closed when a transport stops consuming them.

Validation: `make all` (9,261 passed, 164 skipped); 27 cancellation regression cases, including nested provider finalizers and waiting under a room lock after a cleanup timeout; strict documentation build; runnable cancellation/resume example.

Independent review findings addressed: explicitly close nested provider/retry streams and apply the deadlock guard to full handle completion.
